### PR TITLE
Fix Readme typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@ This library has two main modules:
   - `Browser` &mdash; for creating Elm programs in the browser
   - `Browser.Navigation` &mdash; tools for single-page apps (SPAs)
 
-
-<br>
-
 ## Learning Path
 
 **I highly recommend working through [guide.elm-lang.org][guide] to learn how to use Elm.** It is built around a learning path that introduces concepts gradually.


### PR DESCRIPTION
As `elm-package` project is using `defaultOptions`  and the `defaultOptions` sets the sanitize to `True`, the HTML elements are printed as normal text.

https://github.com/elm/package.elm-lang.org/blob/master/src/frontend/Utils/Markdown.elm#L14
https://github.com/elm-explorations/markdown/blob/master/src/Markdown.elm#L86

![screen shot 2018-06-01 at 18 37 46](https://user-images.githubusercontent.com/1559013/40864613-ed462e10-65ca-11e8-87d1-6d613dc43854.png)
