### PR TITLE
Fix misspellings and function type syntax

### DIFF
--- a/notes/keyboard.md
+++ b/notes/keyboard.md
@@ -1,6 +1,6 @@
 # Which key was pressed?
 
-When you listening for global keyboard events, you very likely want to know *which* key was pressed. Unfortunately different browsers implement the [`KeyboardEvent`][ke] values in different ways, so there is no one-size-fit-all solution.
+When you're listening for global keyboard events, you very likely want to know *which* key was pressed. Unfortunately different browsers implement the [`KeyboardEvent`][ke] values in different ways, so there is no one-size-fits-all solution.
 
 [ke]: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
 

--- a/notes/navigation-in-elements.md
+++ b/notes/navigation-in-elements.md
@@ -78,7 +78,7 @@ port onUrlChange : (String -> msg) -> Sub msg
 
 port pushUrl : String -> Cmd msg
 
-link msg -> List (Attribute msg) -> List (Html msg) -> Html msg
+link : msg -> List (Attribute msg) -> List (Html msg) -> Html msg
 link href attrs children =
   a (preventDefaultOn "click" (D.succeed (href, True)) :: attrs) children
 


### PR DESCRIPTION
I added `:` to `link : msg -> List (Attribute msg) -> List (Html msg) -> Html msg`
and `When you` -> `When you're` 
as well as `one-size-fit-all` -> `one-size-fits-all`