### PR TITLE
remove unneeded function wrap around clearTimeout

### DIFF
--- a/src/Elm/Kernel/Browser.js
+++ b/src/Elm/Kernel/Browser.js
@@ -99,7 +99,7 @@ var _Browser_document = __Debugger_document || F4(function(impl, flagDecoder, de
 var _Browser_cancelAnimationFrame =
 	typeof cancelAnimationFrame !== 'undefined'
 		? cancelAnimationFrame
-		: function(id) { clearTimeout(id); };
+		: clearTimeout;
 
 var _Browser_requestAnimationFrame =
 	typeof requestAnimationFrame !== 'undefined'


### PR DESCRIPTION
This commit removes an unnecessary function allocation in case animation frame is not available.