### PR TITLE
Fix jumpToBottom example in Browser.Dom GitHub docs 

### DIFF
--- a/src/Browser/Dom.elm
+++ b/src/Browser/Dom.elm
@@ -251,7 +251,7 @@ way the latest message is always on screen! You could do this:
     jumpToBottom id =
       Dom.getViewportOf id
         |> Task.andThen (\info -> Dom.setViewportOf id 0 info.scene.height)
-        |> Task.perform (\_ -> NoOp)
+        |> Task.attempt (\_ -> NoOp)
 
 So you could call `jumpToBottom "chat-box"` whenever you add a new message.
 


### PR DESCRIPTION
Fix jumpToBottom example in Browser.Dom GitHub docs by replacing Task.perform  with Task.attempt.