### PR TITLE
Address issue #16, "Debugger click-to-resume overlay broken on 0.19"

### DIFF
--- a/src/Debugger/Overlay.elm
+++ b/src/Debugger/Overlay.elm
@@ -135,13 +135,17 @@ view config isPaused isOpen numMsgs state =
       else
         if isPaused then
           div
-            [ style "width" "100%"
+            [ id "elm-debugger-overlay"
+            , style "width" "100%"
             , style "height" "100%"
             , style "cursor" "pointer"
             , style "text-align" "center"
             , style "pointer-events" "auto"
             , style "background-color" "rgba(200, 200, 200, 0.7)"
             , style "color" "white"
+            , style "position" "fixed"
+            , style "top" "0"
+            , style "left" "0"
             , style "font-family" "'Trebuchet MS', 'Lucida Grande', 'Bitstream Vera Sans', 'Helvetica Neue', sans-serif"
             , style "z-index" "2147483646"
             , onClick config.resume


### PR DESCRIPTION
Add the "elm-debugger-overlay" id to the overlay so that the event listener in Debugger.js, (in the _Debugger_blocker function), can recognize the click event on the overlay and let it through so the program can resume.

Add some styling so the overlay displays as expected.

Note, there are still some issues with multiple popouts getting spawned, but that's for a different day.