### PR TITLE
Fix various debugger issues

### DIFF
--- a/src/Debugger/History.elm
+++ b/src/Debugger/History.elm
@@ -112,7 +112,8 @@ encodeHelp snapshot allMessages =
 
 elmToJs : a -> Encode.Value
 elmToJs =
-  Elm.Kernel.Debugger.unsafeCoerce
+  Elm.Kernel.Json.wrap
+    >> Elm.Kernel.Debugger.unsafeCoerce
 
 
 

--- a/src/Debugger/History.elm
+++ b/src/Debugger/History.elm
@@ -97,7 +97,8 @@ decoder initialModel update =
 
 jsToElm : Encode.Value -> a
 jsToElm =
-  Elm.Kernel.Debugger.unsafeCoerce
+  Elm.Kernel.Json.unwrap
+    >> Elm.Kernel.Debugger.unsafeCoerce
 
 
 encode : History model msg -> Encode.Value

--- a/src/Debugger/Main.elm
+++ b/src/Debugger/Main.elm
@@ -283,6 +283,7 @@ download metadata history =
         [ ("metadata", Metadata.encode metadata)
         , ("history", History.encode history)
         ]
+        |> Elm.Kernel.Json.unwrap
   in
     Task.perform (\_ -> NoOp) (Elm.Kernel.Debugger.download historyLength json)
 

--- a/src/Debugger/Main.elm
+++ b/src/Debugger/Main.elm
@@ -234,7 +234,7 @@ wrapUpdate update msg model =
 
     Import ->
       withGoodMetadata model <| \_ ->
-        ( model, upload )
+        ( model, upload model.popout )
 
     Export ->
       withGoodMetadata model <| \metadata ->
@@ -267,9 +267,9 @@ scroll popout =
   Task.perform (always NoOp) (Elm.Kernel.Debugger.scroll popout)
 
 
-upload : Cmd (Msg msg)
-upload =
-  Task.perform Upload (Elm.Kernel.Debugger.upload ())
+upload : Popout -> Cmd (Msg msg)
+upload popout =
+  Task.perform Upload (Elm.Kernel.Debugger.upload popout)
 
 
 download : Metadata -> History model msg -> Cmd (Msg msg)

--- a/src/Elm/Kernel/Debugger.js
+++ b/src/Elm/Kernel/Debugger.js
@@ -73,12 +73,13 @@ var _Debugger_element = F4(function(impl, flagDecoder, debugMetadata, args)
 
 				// view corner
 
+				var cornerNext = __Main_cornerView(model);
+				var cornerPatches = __VirtualDom_diff(cornerCurr, cornerNext);
+				cornerNode = __VirtualDom_applyPatches(cornerNode, cornerCurr, cornerPatches, sendToApp);
+				cornerCurr = cornerNext;
+
 				if (!model.__$popout.__doc)
 				{
-					var cornerNext = __Main_cornerView(model);
-					var cornerPatches = __VirtualDom_diff(cornerCurr, cornerNext);
-					cornerNode = __VirtualDom_applyPatches(cornerNode, cornerCurr, cornerPatches, sendToApp);
-					cornerCurr = cornerNext;
 					currPopout = undefined;
 					return;
 				}

--- a/src/Elm/Kernel/Debugger.js
+++ b/src/Elm/Kernel/Debugger.js
@@ -236,11 +236,12 @@ function _Debugger_scroll(popout)
 // UPLOAD
 
 
-function _Debugger_upload()
+function _Debugger_upload(popout)
 {
 	return __Scheduler_binding(function(callback)
 	{
-		var element = document.createElement('input');
+		var doc = popout.__doc || document;
+		var element = doc.createElement('input');
 		element.setAttribute('type', 'file');
 		element.setAttribute('accept', 'text/json');
 		element.style.display = 'none';
@@ -252,9 +253,9 @@ function _Debugger_upload()
 				callback(__Scheduler_succeed(e.target.result));
 			};
 			fileReader.readAsText(event.target.files[0]);
-			document.body.removeChild(element);
+			doc.body.removeChild(element);
 		});
-		document.body.appendChild(element);
+		doc.body.appendChild(element);
 		element.click();
 	});
 }


### PR DESCRIPTION
This PR fixes 4 main issues with the time travel debugger, which should close #51 and close elm/compiler#1828:

* Fixes the historical JSON output from export
* Fixes the historical JSON import
* Fixes an issue where the import button didn't work from the popup window
* Ensures the debugger corner view is hidden while the popup window is displayed

I'm not certain these changes are the most optimal for the core team because I don't know all the design decisions that go into Elm from the native code side. I'm especially not sure if using `Elm.Kernel.Json` within the `Debugger` codebase is frowned upon, so I'm open to suggestions on preferred handling of this.

