### PR TITLE
Update link to docs

### DIFF
--- a/src/Browser.elm
+++ b/src/Browser.elm
@@ -1,9 +1,12 @@
-module Browser exposing
-    ( sandbox
-    , element
-    , document, Document
-    , application, UrlRequest(..)
-    )
+module Browser
+    exposing
+        ( sandbox
+        , element
+        , document
+        , Document
+        , application
+        , UrlRequest(..)
+        )
 
 {-| This module helps you set up an Elm `Program` with functions like
 [`sandbox`](#sandbox) and [`document`](#document).
@@ -36,7 +39,6 @@ import Dict
 import Elm.Kernel.Browser
 import Html exposing (Html)
 import Url
-
 
 
 -- SANDBOX
@@ -201,8 +203,7 @@ reading a calculus book from page 314, it might seem confusing. Same here!
 [bnp]: Browser-Navigation#pushUrl
 [bnl]: Browser-Navigation#load
 [url]: /packages/elm/url/latest/Url#Url
-[this]: https://github.com/elm/browser/blob/1.0.0/notes/navigation-in-elements.md
-
+[this]: https://github.com/elm/browser/blob/1.0.1/notes/navigation-in-elements.md
 -}
 application :
     { init : flags -> Url.Url -> Navigation.Key -> ( model, Cmd msg )

--- a/src/Browser/Events.elm
+++ b/src/Browser/Events.elm
@@ -83,7 +83,7 @@ not rely on this for arrow keys.
 **Note:** Check out [this advice][note] to learn more about decoding key codes.
 It is more complicated than it should be.
 
-[note]: https://github.com/elm/browser/blob/1.0.0/notes/keyboard.md
+[note]: https://github.com/elm/browser/blob/1.0.1/notes/keyboard.md
 
 -}
 onKeyPress : Decode.Decoder msg -> Sub msg
@@ -98,8 +98,8 @@ or `d` at any given time. Check out how that works in [this example][example].
 **Note:** Check out [this advice][note] to learn more about decoding key codes.
 It is more complicated than it should be.
 
-[note]: https://github.com/elm/browser/blob/1.0.0/notes/keyboard.md
-[example]: https://github.com/elm/browser/blob/1.0.0/examples/wasd.md
+[note]: https://github.com/elm/browser/blob/1.0.1/notes/keyboard.md
+[example]: https://github.com/elm/browser/blob/1.0.1/examples/wasd.md
 
 -}
 onKeyDown : Decode.Decoder msg -> Sub msg
@@ -209,7 +209,7 @@ This may also be useful with [`onKeyDown`](#onKeyDown). If you only listen for
 a keyboard shortcut to switch tabs. Visibility changes will cover those tricky
 cases, like in [this example][example]!
 
-[example]: https://github.com/elm/browser/blob/1.0.0/examples/wasd.md
+[example]: https://github.com/elm/browser/blob/1.0.1/examples/wasd.md
 
 -}
 onVisibilityChange : (Visibility -> msg) -> Sub msg

--- a/src/Browser/Navigation.elm
+++ b/src/Browser/Navigation.elm
@@ -61,7 +61,7 @@ equipped to detect these URL changes. If `Key` values were available in other
 kinds of programs, unsuspecting programmers would be sure to run into some
 [annoying bugs][bugs] and learn a bunch of techniques the hard way!
 
-[bugs]: https://github.com/elm/browser/blob/1.0.0/notes/navigation-in-elements.md
+[bugs]: https://github.com/elm/browser/blob/1.0.1/notes/navigation-in-elements.md
 
 -}
 type Key


### PR DESCRIPTION
The link to the 'manage URL from a Browser.element docs' pointed to the 1.0.0 version which has a typo (`document.addEventListener` instead of `window.addEventListener`) that tripped me up.

Here is the diff between [1.0.0 and 1.0.1 for navigation-in-elements.md
](https://github.com/elm/browser/compare/1.0.0...1.0.1#diff-a2f9e23a348705ae722205caba13f316)