### PR TITLE
Debugger improvements

### DIFF
--- a/src/Browser.elm
+++ b/src/Browser.elm
@@ -1,30 +1,34 @@
 module Browser exposing
-  ( sandbox
-  , element
-  , document
-  , Document
-  , application
-  , UrlRequest(..)
-  )
+    ( sandbox
+    , element
+    , document, Document
+    , application, UrlRequest(..)
+    )
 
 {-| This module helps you set up an Elm `Program` with functions like
 [`sandbox`](#sandbox) and [`document`](#document).
 
 
 # Sandboxes
+
 @docs sandbox
 
+
 # Elements
+
 @docs element
 
+
 # Documents
+
 @docs document, Document
 
+
 # Applications
+
 @docs application, UrlRequest
 
 -}
-
 
 import Browser.Navigation as Navigation
 import Debugger.Main
@@ -54,20 +58,21 @@ fundamentals actually pays off in this language!
 
 [tea]: https://guide.elm-lang.org/architecture/
 [guide]: https://guide.elm-lang.org/
+
 -}
 sandbox :
-  { init : model
-  , view : model -> Html msg
-  , update : msg -> model -> model
-  }
-  -> Program () model msg
-sandbox impl =
-  Elm.Kernel.Browser.element
-    { init = \() -> (impl.init, Cmd.none)
-    , view = impl.view
-    , update = \msg model -> (impl.update msg model, Cmd.none)
-    , subscriptions = \_ -> Sub.none
+    { init : model
+    , view : model -> Html msg
+    , update : msg -> model -> model
     }
+    -> Program () model msg
+sandbox impl =
+    Elm.Kernel.Browser.element
+        { init = \() -> ( impl.init, Cmd.none )
+        , view = impl.view
+        , update = \msg model -> ( impl.update msg model, Cmd.none )
+        , subscriptions = \_ -> Sub.none
+        }
 
 
 
@@ -94,16 +99,17 @@ section][interop].
 [guide]: https://guide.elm-lang.org/
 [fx]: https://guide.elm-lang.org/effects/
 [interop]: https://guide.elm-lang.org/interop/
+
 -}
 element :
-  { init : flags -> (model, Cmd msg)
-  , view : model -> Html msg
-  , update : msg -> model -> ( model, Cmd msg )
-  , subscriptions : model -> Sub msg
-  }
-  -> Program flags model msg
+    { init : flags -> ( model, Cmd msg )
+    , view : model -> Html msg
+    , update : msg -> model -> ( model, Cmd msg )
+    , subscriptions : model -> Sub msg
+    }
+    -> Program flags model msg
 element =
-  Elm.Kernel.Browser.element
+    Elm.Kernel.Browser.element
 
 
 
@@ -112,17 +118,16 @@ element =
 
 {-| Create an HTML document managed by Elm. This expands upon what `element`
 can do in that `view` now gives you control over the `<title>` and `<body>`.
-
 -}
 document :
-  { init : flags -> (model, Cmd msg)
-  , view : model -> Document msg
-  , update : msg -> model -> ( model, Cmd msg )
-  , subscriptions : model -> Sub msg
-  }
-  -> Program flags model msg
+    { init : flags -> ( model, Cmd msg )
+    , view : model -> Document msg
+    , update : msg -> model -> ( model, Cmd msg )
+    , subscriptions : model -> Sub msg
+    }
+    -> Program flags model msg
 document =
-  Elm.Kernel.Browser.document
+    Elm.Kernel.Browser.document
 
 
 {-| This data specifies the `<title>` and all of the nodes that should go in
@@ -134,28 +139,29 @@ app shows an accurate date in the title, etc.
 > not the place to manage CSS assets. If you want to work with CSS, there are
 > a couple ways:
 >
-> 1. Packages like [`rtfeldman/elm-css`][elm-css] give all of the features
-> of CSS without any CSS files. You can add all the styles you need in your
-> `view` function, and there is no need to worry about class names matching.
+> 1.  Packages like [`rtfeldman/elm-css`][elm-css] give all of the features
+>     of CSS without any CSS files. You can add all the styles you need in your
+>     `view` function, and there is no need to worry about class names matching.
 >
-> 2. Compile your Elm code to JavaScript with `elm make --output=elm.js` and
-> then make your own HTML file that loads `elm.js` and the CSS file you want.
-> With this approach, it does not matter where the CSS comes from. Write it
-> by hand. Generate it. Whatever you want to do.
+> 2.  Compile your Elm code to JavaScript with `elm make --output=elm.js` and
+>     then make your own HTML file that loads `elm.js` and the CSS file you want.
+>     With this approach, it does not matter where the CSS comes from. Write it
+>     by hand. Generate it. Whatever you want to do.
 >
-> 3. If you need to change `<link>` tags dynamically, you can send messages
-> out a port to do it in JavaScript.
+> 3.  If you need to change `<link>` tags dynamically, you can send messages
+>     out a port to do it in JavaScript.
 >
 > The bigger point here is that loading assets involves touching the `<head>`
 > as an implementation detail of browsers, but that does not mean it should be
 > the responsibility of the `view` function in Elm. So we do it differently!
 
 [elm-css]: /rtfeldman/elm-css/latest/
+
 -}
 type alias Document msg =
-  { title : String
-  , body : List (Html msg)
-  }
+    { title : String
+    , body : List (Html msg)
+    }
 
 
 
@@ -181,14 +187,14 @@ control over `Url` changes.
 
 **More Info:** Here are some example usages of `application` programs:
 
-- [RealWorld example app](https://github.com/rtfeldman/elm-spa-example)
-- [Elm’s package website](https://github.com/elm/package.elm-lang.org)
+  - [RealWorld example app](https://github.com/rtfeldman/elm-spa-example)
+  - [Elm’s package website](https://github.com/elm/package.elm-lang.org)
 
 These are quite advanced Elm programs, so be sure to go through [the guide][g]
 first to get a solid conceptual foundation before diving in! If you start
 reading a calculus book from page 314, it might seem confusing. Same here!
 
-**Note:** Can an [`element`](#element) manage the URL too? Read [this][]!
+**Note:** Can an [`element`](#element) manage the URL too? Read [this]!
 
 [g]: https://guide.elm-lang.org/
 [bn]: Browser-Navigation
@@ -196,43 +202,46 @@ reading a calculus book from page 314, it might seem confusing. Same here!
 [bnl]: Browser-Navigation#load
 [url]: /packages/elm/url/latest/Url#Url
 [this]: https://github.com/elm/browser/blob/1.0.0/notes/navigation-in-elements.md
+
 -}
 application :
-  { init : flags -> Url.Url -> Navigation.Key -> (model, Cmd msg)
-  , view : model -> Document msg
-  , update : msg -> model -> ( model, Cmd msg )
-  , subscriptions : model -> Sub msg
-  , onUrlRequest : UrlRequest -> msg
-  , onUrlChange : Url.Url -> msg
-  }
-  -> Program flags model msg
+    { init : flags -> Url.Url -> Navigation.Key -> ( model, Cmd msg )
+    , view : model -> Document msg
+    , update : msg -> model -> ( model, Cmd msg )
+    , subscriptions : model -> Sub msg
+    , onUrlRequest : UrlRequest -> msg
+    , onUrlChange : Url.Url -> msg
+    }
+    -> Program flags model msg
 application =
-  Elm.Kernel.Browser.application
+    Elm.Kernel.Browser.application
 
 
 {-| All links in an [`application`](#application) create a `UrlRequest`. So
 when you click `<a href="/home">Home</a>`, it does not just navigate! It
 notifies `onUrlRequest` that the user wants to change the `Url`.
 
+
 ### `Internal` vs `External`
 
 Imagine we are browsing `https://example.com`. An `Internal` link would be
 like:
 
-- `settings#privacy`
-- `/home`
-- `https://example.com/home`
-- `//example.com/home`
+  - `settings#privacy`
+  - `/home`
+  - `https://example.com/home`
+  - `//example.com/home`
 
 All of these links exist under the `https://example.com` domain. An `External`
 link would be like:
 
-- `https://elm-lang.org/examples`
-- `https://other.example.com/home`
-- `http://example.com/home`
+  - `https://elm-lang.org/examples`
+  - `https://other.example.com/home`
+  - `http://example.com/home`
 
 Anything that changes the domain. Notice that changing the protocol from
 `https` to `http` is considered a different domain! (And vice versa!)
+
 
 ### Purpose
 
@@ -242,22 +251,23 @@ Having a `UrlRequest` requires a case in your `update` like this:
     import Browser.Navigation as Nav
     import Url
 
-    type Msg = ClickedLink UrlRequest
+    type Msg
+        = ClickedLink UrlRequest
 
-    update : Msg -> Model -> (Model, Cmd msg)
+    update : Msg -> Model -> ( Model, Cmd msg )
     update msg model =
-      case msg of
-        ClickedLink urlRequest ->
-          case urlRequest of
-            Internal url ->
-              ( model
-              , Nav.pushUrl model.key (Url.toString url)
-              )
+        case msg of
+            ClickedLink urlRequest ->
+                case urlRequest of
+                    Internal url ->
+                        ( model
+                        , Nav.pushUrl model.key (Url.toString url)
+                        )
 
-            External url ->
-              ( model
-              , Nav.load url
-              )
+                    External url ->
+                        ( model
+                        , Nav.load url
+                        )
 
 This is useful because it gives you a chance to customize the behavior in each
 case. Maybe on some `Internal` links you save the scroll position with
@@ -272,7 +282,8 @@ browser dimensions change? The scroll position will not correlate with
 example, in a Wikipedia article, remember the header that they were looking at
 most recently. [`Browser.Dom.getElement`](Browser-Dom#getElement) is designed
 for figuring that out!
+
 -}
 type UrlRequest
-  = Internal Url.Url
-  | External String
+    = Internal Url.Url
+    | External String

--- a/src/Browser/AnimationManager.elm
+++ b/src/Browser/AnimationManager.elm
@@ -1,8 +1,7 @@
 effect module Browser.AnimationManager where { subscription = MySub } exposing
-  ( onAnimationFrame
-  , onAnimationFrameDelta
-  )
-
+    ( onAnimationFrame
+    , onAnimationFrameDelta
+    )
 
 import Elm.Kernel.Browser
 import Process
@@ -16,12 +15,12 @@ import Time
 
 onAnimationFrame : (Time.Posix -> msg) -> Sub msg
 onAnimationFrame tagger =
-  subscription (Time tagger)
+    subscription (Time tagger)
 
 
 onAnimationFrameDelta : (Float -> msg) -> Sub msg
 onAnimationFrameDelta tagger =
-  subscription (Delta tagger)
+    subscription (Delta tagger)
 
 
 
@@ -29,18 +28,18 @@ onAnimationFrameDelta tagger =
 
 
 type MySub msg
-  = Time (Time.Posix -> msg)
-  | Delta (Float -> msg)
+    = Time (Time.Posix -> msg)
+    | Delta (Float -> msg)
 
 
 subMap : (a -> b) -> MySub a -> MySub b
 subMap func sub =
-  case sub of
-    Time tagger ->
-      Time (func << tagger)
+    case sub of
+        Time tagger ->
+            Time (func << tagger)
 
-    Delta tagger ->
-      Delta (func << tagger)
+        Delta tagger ->
+            Delta (func << tagger)
 
 
 
@@ -48,59 +47,68 @@ subMap func sub =
 
 
 type alias State msg =
-  { subs : List (MySub msg)
-  , request : Maybe Process.Id
-  , oldTime : Int
-  }
+    { subs : List (MySub msg)
+    , request : Maybe Process.Id
+    , oldTime : Int
+    }
+
 
 
 -- NOTE: used in onEffects
 --
+
+
 init : Task Never (State msg)
 init =
-  Task.succeed (State [] Nothing 0)
+    Task.succeed (State [] Nothing 0)
 
 
 onEffects : Platform.Router msg Int -> List (MySub msg) -> State msg -> Task Never (State msg)
-onEffects router subs {request, oldTime} =
-  case (request, subs) of
-    (Nothing, []) ->
-      init
+onEffects router subs { request, oldTime } =
+    case ( request, subs ) of
+        ( Nothing, [] ) ->
+            init
 
-    (Just pid, []) ->
-      Process.kill pid
-        |> Task.andThen (\_ -> init)
+        ( Just pid, [] ) ->
+            Process.kill pid
+                |> Task.andThen (\_ -> init)
 
-    (Nothing, _) ->
-      Process.spawn (Task.andThen (Platform.sendToSelf router) rAF)
-        |> Task.andThen (\pid -> now
-        |> Task.andThen (\time -> Task.succeed (State subs (Just pid) time)))
+        ( Nothing, _ ) ->
+            Process.spawn (Task.andThen (Platform.sendToSelf router) rAF)
+                |> Task.andThen
+                    (\pid ->
+                        now
+                            |> Task.andThen (\time -> Task.succeed (State subs (Just pid) time))
+                    )
 
-    (Just _, _) ->
-      Task.succeed (State subs request oldTime)
+        ( Just _, _ ) ->
+            Task.succeed (State subs request oldTime)
 
 
 onSelfMsg : Platform.Router msg Int -> Int -> State msg -> Task Never (State msg)
-onSelfMsg router newTime {subs, oldTime} =
-  let
-    send sub =
-      case sub of
-        Time tagger ->
-          Platform.sendToApp router (tagger (Time.millisToPosix newTime))
+onSelfMsg router newTime { subs, oldTime } =
+    let
+        send sub =
+            case sub of
+                Time tagger ->
+                    Platform.sendToApp router (tagger (Time.millisToPosix newTime))
 
-        Delta tagger ->
-          Platform.sendToApp router (tagger (toFloat (newTime - oldTime)))
-  in
-  Process.spawn (Task.andThen (Platform.sendToSelf router) rAF)
-    |> Task.andThen (\pid -> Task.sequence (List.map send subs)
-    |> Task.andThen (\_ -> Task.succeed (State subs (Just pid) newTime)))
+                Delta tagger ->
+                    Platform.sendToApp router (tagger (toFloat (newTime - oldTime)))
+    in
+    Process.spawn (Task.andThen (Platform.sendToSelf router) rAF)
+        |> Task.andThen
+            (\pid ->
+                Task.sequence (List.map send subs)
+                    |> Task.andThen (\_ -> Task.succeed (State subs (Just pid) newTime))
+            )
 
 
 rAF : Task x Int
 rAF =
-  Elm.Kernel.Browser.rAF ()
+    Elm.Kernel.Browser.rAF ()
 
 
 now : Task x Int
 now =
-  Elm.Kernel.Browser.now ()
+    Elm.Kernel.Browser.now ()

--- a/src/Browser/Dom.elm
+++ b/src/Browser/Dom.elm
@@ -1,18 +1,17 @@
 module Browser.Dom exposing
-  ( focus, blur, Error(..)
-  , getViewport, Viewport, getViewportOf
-  , setViewport, setViewportOf
-  , getElement, Element
-  )
-
+    ( focus, blur, Error(..)
+    , getViewport, Viewport, getViewportOf
+    , setViewport, setViewportOf
+    , getElement, Element
+    )
 
 {-| This module allows you to manipulate the DOM in various ways. It covers:
 
-- Focus and blur input elements.
-- Get the `width` and `height` of elements.
-- Get the `x` and `y` coordinates of elements.
-- Figure out the scroll position.
-- Change the scroll position!
+  - Focus and blur input elements.
+  - Get the `width` and `height` of elements.
+  - Get the `x` and `y` coordinates of elements.
+  - Figure out the scroll position.
+  - Change the scroll position!
 
 We use different terminology than JavaScript though...
 
@@ -49,21 +48,27 @@ Hockney explores the history of _perspective_ in art. Really interesting!
 [hang]: https://en.wikipedia.org/wiki/Hanging_scroll
 [doc]: https://www.imdb.com/title/tt0164525/
 
+
 # Focus
+
 @docs focus, blur, Error
 
+
 # Get Viewport
+
 @docs getViewport, Viewport, getViewportOf
 
+
 # Set Viewport
+
 @docs setViewport, setViewportOf
 
+
 # Position
+
 @docs getElement, Element
 
 -}
-
-
 
 import Elm.Kernel.Browser
 import Task exposing (Task)
@@ -79,19 +84,21 @@ like `<input type="text" id="search-box">` you could say:
     import Browser.Dom as Dom
     import Task
 
-    type Msg = NoOp
+    type Msg
+        = NoOp
 
     focusSearchBox : Cmd Msg
     focusSearchBox =
-      Task.attempt (\_ -> NoOp) (Dom.focus "search-box")
+        Task.attempt (\_ -> NoOp) (Dom.focus "search-box")
 
 Notice that this code ignores the possibility that `search-box` is not used
 as an `id` by any node, failing silently in that case. It would be better to
 log the failure with whatever error reporting system you use.
+
 -}
 focus : String -> Task Error ()
 focus =
-  Elm.Kernel.Browser.call "focus"
+    Elm.Kernel.Browser.call "focus"
 
 
 {-| Find a DOM node by `id` and make it lose focus. So if you wanted a node
@@ -100,19 +107,21 @@ like `<input type="text" id="search-box">` to lose focus you could say:
     import Browser.Dom as Dom
     import Task
 
-    type Msg = NoOp
+    type Msg
+        = NoOp
 
     unfocusSearchBox : Cmd Msg
     unfocusSearchBox =
-      Task.attempt (\_ -> NoOp) (Dom.blur "search-box")
+        Task.attempt (\_ -> NoOp) (Dom.blur "search-box")
 
 Notice that this code ignores the possibility that `search-box` is not used
 as an `id` by any node, failing silently in that case. It would be better to
 log the failure with whatever error reporting system you use.
+
 -}
 blur : String -> Task Error ()
 blur =
-  Elm.Kernel.Browser.call "blur"
+    Elm.Kernel.Browser.call "blur"
 
 
 
@@ -122,7 +131,8 @@ blur =
 {-| Many functions in this module look up DOM nodes up by their `id`. If you
 ask for an `id` that is not in the DOM, you will get this error.
 -}
-type Error = NotFound String
+type Error
+    = NotFound String
 
 
 
@@ -136,11 +146,11 @@ type Error = NotFound String
 If you want to move the viewport around (i.e. change the scroll position) you
 can use [`setViewport`](#setViewport) which change the `x` and `y` of the
 viewport.
+
 -}
 getViewport : Task x Viewport
 getViewport =
-  Elm.Kernel.Browser.withWindow Elm.Kernel.Browser.getViewport
-
+    Elm.Kernel.Browser.withWindow Elm.Kernel.Browser.getViewport
 
 
 {-| All the information about the current viewport.
@@ -149,17 +159,17 @@ getViewport =
 
 -}
 type alias Viewport =
-  { scene :
-      { width : Float
-      , height : Float
-      }
-  , viewport :
-      { x : Float
-      , y : Float
-      , width : Float
-      , height : Float
-      }
-  }
+    { scene :
+        { width : Float
+        , height : Float
+        }
+    , viewport :
+        { x : Float
+        , y : Float
+        , width : Float
+        , height : Float
+        }
+    }
 
 
 {-| Just like `getViewport`, but for any scrollable DOM node. Say we have an
@@ -176,17 +186,17 @@ viewport into a scene!
 This can be useful with [`setViewportOf`](#setViewportOf) to make sure new
 messages always appear on the bottom.
 
-The viewport size *does not* include the border or margins.
+The viewport size _does not_ include the border or margins.
 
 **Note:** This data is collected from specific fields in JavaScript, so it
 may be helpful to know that:
 
-- `scene.width` = [`scrollWidth`][sw]
-- `scene.height` = [`scrollHeight`][sh]
-- `viewport.x` = [`scrollLeft`][sl]
-- `viewport.y` = [`scrollTop`][st]
-- `viewport.width` = [`clientWidth`][cw]
-- `viewport.height` = [`clientHeight`][ch]
+  - `scene.width` = [`scrollWidth`][sw]
+  - `scene.height` = [`scrollHeight`][sh]
+  - `viewport.x` = [`scrollLeft`][sl]
+  - `viewport.y` = [`scrollTop`][st]
+  - `viewport.width` = [`clientWidth`][cw]
+  - `viewport.height` = [`clientHeight`][ch]
 
 Neither [`offsetWidth`][ow] nor [`offsetHeight`][oh] are available. The theory
 is that (1) the information can always be obtained by using `getElement` on a
@@ -204,10 +214,11 @@ API improvements!
 [ch]: https://developer.mozilla.org/en-US/docs/Web/API/Element/clientHeight
 [ow]: https://developer.mozilla.org/en-US/docs/Web/API/Element/offsetWidth
 [oh]: https://developer.mozilla.org/en-US/docs/Web/API/Element/offsetHeight
+
 -}
 getViewportOf : String -> Task Error Viewport
 getViewportOf =
-  Elm.Kernel.Browser.getViewportOf
+    Elm.Kernel.Browser.getViewportOf
 
 
 
@@ -220,21 +231,23 @@ example, you could make a command to jump to the top of the page:
     import Browser.Dom as Dom
     import Task
 
-    type Msg = NoOp
+    type Msg
+        = NoOp
 
     resetViewport : Cmd Msg
     resetViewport =
-      Task.perform (\_ -> NoOp) (Dom.setViewport 0 0)
+        Task.perform (\_ -> NoOp) (Dom.setViewport 0 0)
 
 This sets the viewport offset to zero.
 
 This could be useful with `Browser.application` where you may want to reset
 the viewport when the URL changes. Maybe you go to a &ldquo;new page&rdquo;
 and want people to start at the top!
+
 -}
 setViewport : Float -> Float -> Task x ()
 setViewport =
-  Elm.Kernel.Browser.setViewport
+    Elm.Kernel.Browser.setViewport
 
 
 {-| Change the `x` and `y` offset of a DOM node&rsquo;s viewport by ID. This
@@ -245,13 +258,14 @@ way the latest message is always on screen! You could do this:
     import Browser.Dom as Dom
     import Task
 
-    type Msg = NoOp
+    type Msg
+        = NoOp
 
     jumpToBottom : String -> Cmd Msg
     jumpToBottom id =
-      Dom.getViewportOf id
-        |> Task.andThen (\info -> Dom.setViewportOf id 0 info.scene.height)
-        |> Task.attempt (\_ -> NoOp)
+        Dom.getViewportOf id
+            |> Task.andThen (\info -> Dom.setViewportOf id 0 info.scene.height)
+            |> Task.attempt (\_ -> NoOp)
 
 So you could call `jumpToBottom "chat-box"` whenever you add a new message.
 
@@ -265,14 +279,15 @@ back in bounds.
 **Note 2:** The example ignores when the element ID is not found, but it would
 be great to log that information. It means there may be a bug or a dead link
 somewhere!
+
 -}
 setViewportOf : String -> Float -> Float -> Task Error ()
 setViewportOf =
-  Elm.Kernel.Browser.setViewportOf
+    Elm.Kernel.Browser.setViewportOf
 
 
 
-{-- SLIDE VIEWPORT
+{--SLIDE VIEWPORT
 
 
 {-| Change the `x` and `y` offset of the viewport with an animation. In JS,
@@ -309,9 +324,6 @@ slideViewportOf =
   Debug.todo "slideViewportOf"
 
 --}
-
-
-
 -- ELEMENT
 
 
@@ -323,14 +335,14 @@ slideViewportOf =
 
 This can be useful for:
 
-- **Scrolling** &mdash; Pair this information with `setViewport` to scroll
-specific elements into view. This gives you a lot of control over where exactly
-the element would be after the viewport moved.
+  - **Scrolling** &mdash; Pair this information with `setViewport` to scroll
+    specific elements into view. This gives you a lot of control over where exactly
+    the element would be after the viewport moved.
 
-- **Drag and Drop** &mdash; As of this writing, `touchmove` events do not tell
-you which element you are currently above. To figure out if you have dragged
-something over the target, you could see if the `pageX` and `pageY` of the
-touch are inside the `x`, `y`, `width`, and `height` of the target element.
+  - **Drag and Drop** &mdash; As of this writing, `touchmove` events do not tell
+    you which element you are currently above. To figure out if you have dragged
+    something over the target, you could see if the `pageX` and `pageY` of the
+    touch are inside the `x`, `y`, `width`, and `height` of the target element.
 
 **Note:** This corresponds to JavaScript&rsquo;s [`getBoundingClientRect`][gbcr],
 so **the element&rsquo;s margins are included in its `width` and `height`**.
@@ -339,10 +351,11 @@ probably do not, so some folks set the margins to zero and put the target
 element in a `<div>` that adds the spacing. Just something to be aware of!
 
 [gbcr]: https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect
+
 -}
 getElement : String -> Task Error Element
 getElement =
-  Elm.Kernel.Browser.getElement
+    Elm.Kernel.Browser.getElement
 
 
 {-| A bunch of information about the position and size of an element relative
@@ -352,20 +365,20 @@ to the overall scene.
 
 -}
 type alias Element =
-  { scene :
-      { width : Float
-      , height : Float
-      }
-  , viewport :
-      { x : Float
-      , y : Float
-      , width : Float
-      , height : Float
-      }
-  , element :
-      { x : Float
-      , y : Float
-      , width : Float
-      , height : Float
-      }
-  }
+    { scene :
+        { width : Float
+        , height : Float
+        }
+    , viewport :
+        { x : Float
+        , y : Float
+        , width : Float
+        , height : Float
+        }
+    , element :
+        { x : Float
+        , y : Float
+        , width : Float
+        , height : Float
+        }
+    }

--- a/src/Browser/Events.elm
+++ b/src/Browser/Events.elm
@@ -1,34 +1,40 @@
 effect module Browser.Events where { subscription = MySub } exposing
-  ( onAnimationFrame, onAnimationFrameDelta
-  , onKeyPress, onKeyDown, onKeyUp
-  , onClick, onMouseMove, onMouseDown, onMouseUp
-  , onResize, onVisibilityChange, Visibility(..)
-  )
-
+    ( onAnimationFrame, onAnimationFrameDelta
+    , onKeyPress, onKeyDown, onKeyUp
+    , onClick, onMouseMove, onMouseDown, onMouseUp
+    , onResize, onVisibilityChange, Visibility(..)
+    )
 
 {-| In JavaScript, information about the root of an HTML document is held in
 the `document` and `window` objects. This module lets you create event
 listeners on those objects for the following topics: [animation](#animation),
 [keyboard](#keyboard), [mouse](#mouse), and [window](#window).
 
-If there is something else you need, use [ports][] to do it in JavaScript!
+If there is something else you need, use [ports] to do it in JavaScript!
 
 [ports]: https://guide.elm-lang.org/interop/ports.html
 
+
 # Animation
+
 @docs onAnimationFrame, onAnimationFrameDelta
 
+
 # Keyboard
+
 @docs onKeyPress, onKeyDown, onKeyUp
 
+
 # Mouse
+
 @docs onClick, onMouseMove, onMouseDown, onMouseUp
 
+
 # Window
+
 @docs onResize, onVisibilityChange, Visibility
 
 -}
-
 
 import Browser.AnimationManager as AM
 import Dict
@@ -51,10 +57,11 @@ POSIX times.)
 possible. If you want smooth animations in your application, it is helpful to
 sync up with the browsers natural refresh rate. This hooks into JavaScript's
 `requestAnimationFrame` function.
+
 -}
 onAnimationFrame : (Time.Posix -> msg) -> Sub msg
 onAnimationFrame =
-  AM.onAnimationFrame
+    AM.onAnimationFrame
 
 
 {-| Just like `onAnimationFrame`, except message is the time in milliseconds
@@ -63,7 +70,7 @@ since the previous frame. So you should get a sequence of values all around
 -}
 onAnimationFrameDelta : (Float -> msg) -> Sub msg
 onAnimationFrameDelta =
-  AM.onAnimationFrameDelta
+    AM.onAnimationFrameDelta
 
 
 
@@ -77,10 +84,11 @@ not rely on this for arrow keys.
 It is more complicated than it should be.
 
 [note]: https://github.com/elm/browser/blob/1.0.0/notes/keyboard.md
+
 -}
 onKeyPress : Decode.Decoder msg -> Sub msg
 onKeyPress =
-  on Document "keypress"
+    on Document "keypress"
 
 
 {-| Subscribe to get codes whenever a key goes down. This can be useful for
@@ -92,10 +100,11 @@ It is more complicated than it should be.
 
 [note]: https://github.com/elm/browser/blob/1.0.0/notes/keyboard.md
 [example]: https://github.com/elm/browser/blob/1.0.0/examples/wasd.md
+
 -}
 onKeyDown : Decode.Decoder msg -> Sub msg
 onKeyDown =
-  on Document "keydown"
+    on Document "keydown"
 
 
 {-| Subscribe to get codes whenever a key goes up. Often used in combination
@@ -104,7 +113,7 @@ to down and never come back up.
 -}
 onKeyUp : Decode.Decoder msg -> Sub msg
 onKeyUp =
-  on Document "keyup"
+    on Document "keyup"
 
 
 
@@ -118,20 +127,22 @@ if someone clicked out of it:
     import Browser.Events as Events
     import Json.Decode as D
 
-    type Msg = ClickOut
+    type Msg
+        = ClickOut
 
     subscriptions : Model -> Sub Msg
     subscriptions model =
-      case model.dropDown of
-        Closed _ ->
-          Sub.none
+        case model.dropDown of
+            Closed _ ->
+                Sub.none
 
-        Open _ ->
-          Events.onClick (D.succeed ClickOut)
+            Open _ ->
+                Events.onClick (D.succeed ClickOut)
+
 -}
 onClick : Decode.Decoder msg -> Sub msg
 onClick =
-  on Document "click"
+    on Document "click"
 
 
 {-| Subscribe to mouse moves anywhere on screen. You could use this to implement
@@ -140,17 +151,18 @@ drag and drop.
 **Note:** Unsubscribe if you do not need these events! Running code on every
 single mouse movement can be very costly, and it is recommended to only
 subscribe when absolutely necessary.
+
 -}
 onMouseMove : Decode.Decoder msg -> Sub msg
 onMouseMove =
-  on Document "mousemove"
+    on Document "mousemove"
 
 
 {-| Subscribe to get mouse information whenever the mouse button goes down.
 -}
 onMouseDown : Decode.Decoder msg -> Sub msg
 onMouseDown =
-  on Document "mousedown"
+    on Document "mousedown"
 
 
 {-| Subscribe to get mouse information whenever the mouse button goes up.
@@ -159,7 +171,7 @@ to be sure keys do not appear to down and never come back up.
 -}
 onMouseUp : Decode.Decoder msg -> Sub msg
 onMouseUp =
-  on Document "mouseup"
+    on Document "mouseup"
 
 
 
@@ -174,22 +186,23 @@ this](TODO).
 **Note:** This is equivalent to getting events from [`window.onresize`][resize].
 
 [resize]: https://developer.mozilla.org/en-US/docs/Web/API/GlobalEventHandlers/onresize
+
 -}
 onResize : (Int -> Int -> msg) -> Sub msg
 onResize func =
-  on Window "resize" <|
-    Decode.field "target" <|
-      Decode.map2 func
-        (Decode.field "innerWidth" Decode.int)
-        (Decode.field "innerHeight" Decode.int)
+    on Window "resize" <|
+        Decode.field "target" <|
+            Decode.map2 func
+                (Decode.field "innerWidth" Decode.int)
+                (Decode.field "innerHeight" Decode.int)
 
 
 {-| Subscribe to any visibility changes, like if the user switches to a
 different tab or window. When the user looks away, you may want to:
 
-- Stop polling a server for new information.
-- Pause video or audio.
-- Pause an image carousel.
+  - Stop polling a server for new information.
+  - Pause video or audio.
+  - Pause an image carousel.
 
 This may also be useful with [`onKeyDown`](#onKeyDown). If you only listen for
 [`onKeyUp`](#onKeyUp) to end the key press, you can miss situations like using
@@ -197,26 +210,36 @@ a keyboard shortcut to switch tabs. Visibility changes will cover those tricky
 cases, like in [this example][example]!
 
 [example]: https://github.com/elm/browser/blob/1.0.0/examples/wasd.md
+
 -}
 onVisibilityChange : (Visibility -> msg) -> Sub msg
 onVisibilityChange func =
-  let
-    info = Elm.Kernel.Browser.visibilityInfo ()
-  in
-  on Document info.change <|
-    Decode.map (withHidden func) <|
-      Decode.field "target" <|
-        Decode.field info.hidden Decode.bool
+    let
+        info =
+            Elm.Kernel.Browser.visibilityInfo ()
+    in
+    on Document info.change <|
+        Decode.map (withHidden func) <|
+            Decode.field "target" <|
+                Decode.field info.hidden Decode.bool
 
 
 withHidden : (Visibility -> msg) -> Bool -> msg
 withHidden func isHidden =
-  func (if isHidden then Hidden else Visible)
+    func
+        (if isHidden then
+            Hidden
+
+         else
+            Visible
+        )
 
 
 {-| Value describing whether the page is hidden or visible.
 -}
-type Visibility = Visible | Hidden
+type Visibility
+    = Visible
+    | Hidden
 
 
 
@@ -224,22 +247,22 @@ type Visibility = Visible | Hidden
 
 
 type Node
-  = Document
-  | Window
+    = Document
+    | Window
 
 
 on : Node -> String -> Decode.Decoder msg -> Sub msg
 on node name decoder =
-  subscription (MySub node name decoder)
+    subscription (MySub node name decoder)
 
 
-type MySub msg =
-  MySub Node String (Decode.Decoder msg)
+type MySub msg
+    = MySub Node String (Decode.Decoder msg)
 
 
 subMap : (a -> b) -> MySub a -> MySub b
 subMap func (MySub node name decoder) =
-  MySub node name (Decode.map func decoder)
+    MySub node name (Decode.map func decoder)
 
 
 
@@ -247,59 +270,60 @@ subMap func (MySub node name decoder) =
 
 
 type alias State msg =
-  { subs : List (String, MySub msg)
-  , pids : Dict.Dict String Process.Id
-  }
+    { subs : List ( String, MySub msg )
+    , pids : Dict.Dict String Process.Id
+    }
 
 
 init : Task Never (State msg)
 init =
-  Task.succeed (State [] Dict.empty)
+    Task.succeed (State [] Dict.empty)
 
 
 type alias Event =
-  { key : String
-  , event : Decode.Value
-  }
+    { key : String
+    , event : Decode.Value
+    }
 
 
 onSelfMsg : Platform.Router msg Event -> Event -> State msg -> Task Never (State msg)
 onSelfMsg router { key, event } state =
-  let
-    toMessage (subKey, MySub node name decoder) =
-      if subKey == key then
-        Elm.Kernel.Browser.decodeEvent decoder event
-      else
-        Nothing
+    let
+        toMessage ( subKey, MySub node name decoder ) =
+            if subKey == key then
+                Elm.Kernel.Browser.decodeEvent decoder event
 
-    messages =
-      List.filterMap toMessage state.subs
-  in
-  Task.sequence (List.map (Platform.sendToApp router) messages)
-    |> Task.andThen (\_ -> Task.succeed state)
+            else
+                Nothing
+
+        messages =
+            List.filterMap toMessage state.subs
+    in
+    Task.sequence (List.map (Platform.sendToApp router) messages)
+        |> Task.andThen (\_ -> Task.succeed state)
 
 
 onEffects : Platform.Router msg Event -> List (MySub msg) -> State msg -> Task Never (State msg)
 onEffects router subs state =
-  let
-    newSubs =
-      List.map addKey subs
+    let
+        newSubs =
+            List.map addKey subs
 
-    stepLeft _ pid (deads, lives, news) =
-      ( pid :: deads, lives, news )
+        stepLeft _ pid ( deads, lives, news ) =
+            ( pid :: deads, lives, news )
 
-    stepBoth key pid _ (deads, lives, news) =
-      ( deads, Dict.insert key pid lives, news )
+        stepBoth key pid _ ( deads, lives, news ) =
+            ( deads, Dict.insert key pid lives, news )
 
-    stepRight key sub (deads, lives, news) =
-      ( deads, lives, spawn router key sub :: news )
+        stepRight key sub ( deads, lives, news ) =
+            ( deads, lives, spawn router key sub :: news )
 
-    (deadPids, livePids, makeNewPids) =
-      Dict.merge stepLeft stepBoth stepRight state.pids (Dict.fromList newSubs) ([], Dict.empty, [])
-  in
-  Task.sequence (List.map Process.kill deadPids)
-    |> Task.andThen (\_ -> Task.sequence makeNewPids)
-    |> Task.andThen (\pids -> Task.succeed (State newSubs (Dict.union livePids (Dict.fromList pids))))
+        ( deadPids, livePids, makeNewPids ) =
+            Dict.merge stepLeft stepBoth stepRight state.pids (Dict.fromList newSubs) ( [], Dict.empty, [] )
+    in
+    Task.sequence (List.map Process.kill deadPids)
+        |> Task.andThen (\_ -> Task.sequence makeNewPids)
+        |> Task.andThen (\pids -> Task.succeed (State newSubs (Dict.union livePids (Dict.fromList pids))))
 
 
 
@@ -307,35 +331,35 @@ onEffects router subs state =
 
 
 addKey : MySub msg -> ( String, MySub msg )
-addKey (MySub node name _ as sub) =
-  ( nodeToKey node ++ name, sub )
+addKey ((MySub node name _) as sub) =
+    ( nodeToKey node ++ name, sub )
 
 
 nodeToKey : Node -> String
 nodeToKey node =
-  case node of
-    Document ->
-      "d_"
+    case node of
+        Document ->
+            "d_"
 
-    Window ->
-      "w_"
+        Window ->
+            "w_"
 
 
 
 -- SPAWN
 
 
-spawn : Platform.Router msg Event -> String -> MySub msg -> Task Never (String, Process.Id)
+spawn : Platform.Router msg Event -> String -> MySub msg -> Task Never ( String, Process.Id )
 spawn router key (MySub node name _) =
-  let
-    actualNode =
-      case node of
-        Document ->
-          Elm.Kernel.Browser.doc
+    let
+        actualNode =
+            case node of
+                Document ->
+                    Elm.Kernel.Browser.doc
 
-        Window ->
-          Elm.Kernel.Browser.window
-  in
-  Task.map (\value -> (key,value)) <|
-    Elm.Kernel.Browser.on actualNode name <|
-      \event -> Platform.sendToSelf router (Event key event)
+                Window ->
+                    Elm.Kernel.Browser.window
+    in
+    Task.map (\value -> ( key, value )) <|
+        Elm.Kernel.Browser.on actualNode name <|
+            \event -> Platform.sendToSelf router (Event key event)

--- a/src/Browser/Navigation.elm
+++ b/src/Browser/Navigation.elm
@@ -1,28 +1,21 @@
 module Browser.Navigation exposing
-  ( Key
-  , pushUrl
-  , replaceUrl
-  , back
-  , forward
-  , load
-  , reload
-  , reloadAndSkipCache
-  )
-
+    ( Key, pushUrl, replaceUrl, back, forward
+    , load, reload, reloadAndSkipCache
+    )
 
 {-| This module helps you manage the browser’s URL yourself. This is the
 crucial trick when using [`Browser.application`](Browser#application).
 
 The most important function is [`pushUrl`](#pushUrl) which changes the
-address bar *without* starting a page load.
+address bar _without_ starting a page load.
 
 
 ## What is a page load?
 
-  1. Request a new HTML document. The page goes blank.
-  2. As the HTML loads, request any `<script>` or `<link>` resources.
-  3. A `<script>` may mutate the document, so these tags block rendering.
-  4. When *all* of the assets are loaded, actually render the page.
+1.  Request a new HTML document. The page goes blank.
+2.  As the HTML loads, request any `<script>` or `<link>` resources.
+3.  A `<script>` may mutate the document, so these tags block rendering.
+4.  When _all_ of the assets are loaded, actually render the page.
 
 That means the page will go blank for at least two round-trips to the servers!
 You may have 90% of the data you need and be blocked on a font that is taking
@@ -32,7 +25,7 @@ a long time. Still blank!
 ## How does `pushUrl` help?
 
 The `pushUrl` function changes the URL, but lets you keep the current HTML.
-This means the page *never* goes blank. Instead of making two round-trips to
+This means the page _never_ goes blank. Instead of making two round-trips to
 the server, you load whatever assets you want from within Elm. Maybe you do
 not need any round-trips! Meanwhile, you retain full control over the UI, so
 you can show a loading bar, show information as it loads, etc. Whatever you
@@ -40,13 +33,15 @@ want!
 
 
 # Navigate within Page
+
 @docs Key, pushUrl, replaceUrl, back, forward
 
+
 # Navigate to other Pages
+
 @docs load, reload, reloadAndSkipCache
 
 -}
-
 
 import Elm.Kernel.Browser
 import Task exposing (Task)
@@ -67,8 +62,10 @@ kinds of programs, unsuspecting programmers would be sure to run into some
 [annoying bugs][bugs] and learn a bunch of techniques the hard way!
 
 [bugs]: https://github.com/elm/browser/blob/1.0.0/notes/navigation-in-elements.md
+
 -}
-type Key = Key
+type Key
+    = Key
 
 
 {-| Change the URL, but do not trigger a page load.
@@ -76,7 +73,7 @@ type Key = Key
 This will add a new entry to the browser history.
 
 Check out the [`elm/url`][url] package for help building URLs. The
-[`Url.Builder.absolute`][abs] and [`Url.Builder.relative`][rel] functions can 
+[`Url.Builder.absolute`][abs] and [`Url.Builder.relative`][rel] functions can
 be particularly handy!
 
 [url]: /packages/elm/url/latest
@@ -87,51 +84,55 @@ be particularly handy!
 pages&rdquo; that the user can go `forward` to. Adding a new URL in that
 scenario will clear out any future pages. It is like going back in time and
 making a different choice.
+
 -}
 pushUrl : Key -> String -> Cmd msg
 pushUrl =
-  Elm.Kernel.Browser.pushUrl
+    Elm.Kernel.Browser.pushUrl
 
 
 {-| Change the URL, but do not trigger a page load.
 
-This *will not* add a new entry to the browser history.
+This _will not_ add a new entry to the browser history.
 
 This can be useful if you have search box and you want the `?search=hats` in
 the URL to match without adding a history entry for every single key stroke.
 Imagine how annoying it would be to click `back` thirty times and still be on
 the same page!
+
 -}
 replaceUrl : Key -> String -> Cmd msg
 replaceUrl =
-  Elm.Kernel.Browser.replaceUrl
+    Elm.Kernel.Browser.replaceUrl
 
 
 {-| Go back some number of pages. So `back 1` goes back one page, and `back 2`
 goes back two pages.
 
-**Note:** You only manage the browser history that *you* created. Think of this
+**Note:** You only manage the browser history that _you_ created. Think of this
 library as letting you have access to a small part of the overall history. So
 if you go back farther than the history you own, you will just go back to some
 other website!
+
 -}
 back : Key -> Int -> Cmd msg
 back key n =
-  Elm.Kernel.Browser.go key -n
+    Elm.Kernel.Browser.go key -n
 
 
 {-| Go forward some number of pages. So `forward 1` goes forward one page, and
 `forward 2` goes forward two pages. If there are no more pages in the future,
 this will do nothing.
 
-**Note:** You only manage the browser history that *you* created. Think of this
+**Note:** You only manage the browser history that _you_ created. Think of this
 library as letting you have access to a small part of the overall history. So
 if you go forward farther than the history you own, the user will end up on
 whatever website they visited next!
+
 -}
 forward : Key -> Int -> Cmd msg
 forward =
-  Elm.Kernel.Browser.go
+    Elm.Kernel.Browser.go
 
 
 
@@ -143,7 +144,7 @@ page load**, even if the provided URL is the same as the current one.
 
     gotoElmWebsite : Cmd msg
     gotoElmWebsite =
-      load "https://elm-lang.org"
+        load "https://elm-lang.org"
 
 Check out the [`elm/url`][url] package for help building URLs. The
 [`Url.absolute`][abs] and [`Url.relative`][rel] functions can be particularly
@@ -156,7 +157,7 @@ handy!
 -}
 load : String -> Cmd msg
 load =
-  Elm.Kernel.Browser.load
+    Elm.Kernel.Browser.load
 
 
 {-| Reload the current page. **This always results in a page load!**
@@ -166,7 +167,7 @@ if you want to be sure that you are not loading any cached resources.
 -}
 reload : Cmd msg
 reload =
-  Elm.Kernel.Browser.reload False
+    Elm.Kernel.Browser.reload False
 
 
 {-| Reload the current page without using the browser cache. **This always
@@ -174,4 +175,4 @@ results in a page load!** It is more common to want [`reload`](#reload).
 -}
 reloadAndSkipCache : Cmd msg
 reloadAndSkipCache =
-  Elm.Kernel.Browser.reload True
+    Elm.Kernel.Browser.reload True

--- a/src/Debugger/Expando.elm
+++ b/src/Debugger/Expando.elm
@@ -3,9 +3,6 @@ module Debugger.Expando exposing
     , Msg
     , init
     , merge
-    , prefix
-    , sharedPrefix
-    , toString
     , update
     , view
     )
@@ -107,73 +104,6 @@ initHelp isOuter expando =
 
             else
                 expando
-
-
-
--- Message path
-
-
-sharedPrefix : Expando -> Expando -> Maybe ( String, Expando, Expando )
-sharedPrefix left right =
-    case ( left, right ) of
-        ( Constructor (Just leftName) _ (leftChild :: []), Constructor (Just rightName) _ (rightChild :: []) ) ->
-            if leftName == rightName then
-                Just ( leftName, leftChild, rightChild )
-
-            else
-                Nothing
-
-        _ ->
-            Nothing
-
-
-prefix : Expando -> Maybe ( String, Expando )
-prefix expando =
-    case expando of
-        Constructor (Just name) _ (firstArg :: []) ->
-            Just ( name, firstArg )
-
-        _ ->
-            Nothing
-
-
-toString : Bool -> Expando -> String
-toString isOuter expando =
-    case expando of
-        S string ->
-            string
-
-        Primitive string ->
-            string
-
-        Sequence seqType bool expandoList ->
-            seqTypeToString (List.length expandoList) seqType
-
-        Dictionary bool expandoList ->
-            "Dict (" ++ String.fromInt (List.length expandoList) ++ ")"
-
-        Record bool expandoStringDict ->
-            "{...}"
-
-        Constructor stringMaybe bool expandoList ->
-            if List.isEmpty expandoList then
-                Maybe.withDefault "" stringMaybe
-
-            else
-                let
-                    childrenView =
-                        expandoList
-                            |> List.map (\arg -> toString False arg)
-                            |> String.join " "
-
-                    stringRep =
-                        Maybe.withDefault "" stringMaybe ++ " " ++ childrenView
-                in
-                if isOuter then
-                    stringRep
-
-                else
-                    "(" ++ stringRep ++ ")"
 
 
 

--- a/src/Debugger/Expando.elm
+++ b/src/Debugger/Expando.elm
@@ -3,6 +3,7 @@ module Debugger.Expando exposing
     , Msg
     , init
     , merge
+    , messagePath
     , update
     , view
     )
@@ -104,6 +105,30 @@ initHelp isOuter expando =
 
             else
                 expando
+
+
+
+-- Message path
+
+
+messagePath : a -> List String
+messagePath value =
+    List.reverse (messagePathHelp [] (Elm.Kernel.Debugger.init value))
+
+
+messagePathHelp : List String -> Expando -> List String
+messagePathHelp path value =
+    case value of
+        Constructor (Just name) _ args ->
+            case args of
+                firstArg :: [] ->
+                    messagePathHelp (name :: path) firstArg
+
+                _ ->
+                    path
+
+        _ ->
+            path
 
 
 

--- a/src/Debugger/Expando.elm
+++ b/src/Debugger/Expando.elm
@@ -183,13 +183,13 @@ update : Msg -> Expando -> Expando
 update msg value =
     case value of
         S _ ->
+            -- Debug.crash "nothing changes a primitive"
             value
 
-        -- Debug.crash "nothing changes a primitive"
         Primitive _ ->
+            -- Debug.crash "nothing changes a primitive"
             value
 
-        -- Debug.crash "nothing changes a primitive"
         Sequence seqType isClosed valueList ->
             case msg of
                 Toggle ->
@@ -200,13 +200,13 @@ update msg value =
                         updateIndex index (update subMsg) valueList
 
                 Index _ _ _ ->
+                    -- Debug.crash "no redirected indexes on sequences"
                     value
 
-                -- Debug.crash "no redirected indexes on sequences"
                 Field _ _ ->
+                    -- Debug.crash "no field on sequences"
                     value
 
-        -- Debug.crash "no field on sequences"
         Dictionary isClosed keyValuePairs ->
             case msg of
                 Toggle ->
@@ -215,9 +215,9 @@ update msg value =
                 Index redirect index subMsg ->
                     case redirect of
                         None ->
+                            -- Debug.crash "must have redirect for dictionaries"
                             value
 
-                        -- Debug.crash "must have redirect for dictionaries"
                         Key ->
                             Dictionary isClosed <|
                                 updateIndex index (\( k, v ) -> ( update subMsg k, v )) keyValuePairs
@@ -227,18 +227,18 @@ update msg value =
                                 updateIndex index (\( k, v ) -> ( k, update subMsg v )) keyValuePairs
 
                 Field _ _ ->
+                    -- Debug.crash "no field for dictionaries"
                     value
 
-        -- Debug.crash "no field for dictionaries"
         Record isClosed valueDict ->
             case msg of
                 Toggle ->
                     Record (not isClosed) valueDict
 
                 Index _ _ _ ->
+                    -- Debug.crash "no index for records"
                     value
 
-                -- Debug.crash "no index for records"
                 Field field subMsg ->
                     Record isClosed (Dict.update field (updateField subMsg) valueDict)
 
@@ -252,15 +252,12 @@ update msg value =
                         updateIndex index (update subMsg) valueList
 
                 Index _ _ _ ->
+                    -- Debug.crash "no redirected indexes on sequences"
                     value
 
-                -- Debug.crash "no redirected indexes on sequences"
                 Field _ _ ->
+                    -- Debug.crash "no field for constructors"
                     value
-
-
-
--- Debug.crash "no field for constructors"
 
 
 updateIndex : Int -> (a -> a) -> List a -> List a
@@ -281,9 +278,9 @@ updateField : Msg -> Maybe Expando -> Maybe Expando
 updateField msg maybeExpando =
     case maybeExpando of
         Nothing ->
+            -- Debug.crash "key does not exist"
             maybeExpando
 
-        -- Debug.crash "key does not exist"
         Just expando ->
             Just (update msg expando)
 

--- a/src/Debugger/History.elm
+++ b/src/Debugger/History.elm
@@ -215,10 +215,10 @@ view maybeIndex { snapshots, recent, numMessages } =
         ( index, height ) =
             case maybeIndex of
                 Nothing ->
-                    ( -1, "calc(100% - 24px)" )
+                    ( -1, "calc(100% - 48px)" )
 
                 Just i ->
-                    ( i, "calc(100% - 54px)" )
+                    ( i, "calc(100% - 78px)" )
 
         oldStuff =
             lazy2 viewSnapshots index snapshots

--- a/src/Debugger/History.elm
+++ b/src/Debugger/History.elm
@@ -315,16 +315,9 @@ get update index history =
                     Array.foldr (getHelp update) (Stepping (remainderBy maxSnapshotSize index) model) messages
 
 
-getRecent : History model msg -> ( model, msg )
-getRecent history =
-    case history.recent.messages of
-        [] ->
-            getRecent history
-
-        recentMsg :: _ ->
-            ( history.recent.model
-            , recentMsg
-            )
+getRecent : (msg -> model -> ( model, a )) -> History model msg -> ( model, msg )
+getRecent update history =
+    get update (history.numMessages - 1) history
 
 
 type GetResult model msg

--- a/src/Debugger/History.elm
+++ b/src/Debugger/History.elm
@@ -221,16 +221,16 @@ undone getResult =
 view : Maybe Int -> History model msg -> Html Int
 view maybeIndex { snapshots, recent, numMessages } =
     let
-        ( index, height ) =
+        ( renderAllMessages, index, height ) =
             case maybeIndex of
                 Nothing ->
-                    ( -1, "calc(100% - 48px)" )
+                    ( False, -1, "calc(100% - 48px)" )
 
                 Just i ->
-                    ( i, "calc(100% - 78px)" )
+                    ( True, i, "calc(100% - 78px)" )
 
         oldStuff =
-            lazy2 viewSnapshots index snapshots
+            lazy3 viewSnapshots renderAllMessages index snapshots
 
         ( _, newStuff ) =
             List.foldl (consMsg index) ( numMessages - 1, [] ) recent.messages
@@ -248,15 +248,22 @@ view maybeIndex { snapshots, recent, numMessages } =
 -- VIEW SNAPSHOTS
 
 
-viewSnapshots : Int -> Array (Snapshot model msg) -> Html Int
-viewSnapshots currentIndex snapshots =
+viewSnapshots : Bool -> Int -> Array (Snapshot model msg) -> Html Int
+viewSnapshots renderAllMessages currentIndex snapshots =
     let
         highIndex =
             maxSnapshotSize * Array.length snapshots
+
+        snapshotsToRender =
+            if renderAllMessages then
+                snapshots
+
+            else
+                Array.slice -2 (Array.length snapshots) snapshots
     in
     div [] <|
         Tuple.second <|
-            Array.foldr (consSnapshot currentIndex) ( highIndex, [] ) snapshots
+            Array.foldr (consSnapshot currentIndex) ( highIndex, [] ) snapshotsToRender
 
 
 consSnapshot : Int -> Snapshot model msg -> ( Int, List (Html Int) ) -> ( Int, List (Html Int) )

--- a/src/Debugger/History.elm
+++ b/src/Debugger/History.elm
@@ -7,6 +7,7 @@ module Debugger.History exposing
     , get
     , getInitialModel
     , getRecent
+    , idForMessageIndex
     , size
     , view
     )
@@ -308,7 +309,8 @@ viewMessage currentIndex index msg =
             Elm.Kernel.Debugger.messageToString msg
     in
     div
-        [ class className
+        [ id (idForMessageIndex index)
+        , class className
         , onClick index
         ]
         [ span [ class "elm-debugger-entry-arrow" ]
@@ -325,6 +327,11 @@ viewMessage currentIndex index msg =
             [ text (String.fromInt index)
             ]
         ]
+
+
+idForMessageIndex : Int -> String
+idForMessageIndex index =
+    "msg-" ++ String.fromInt index
 
 
 

--- a/src/Debugger/History.elm
+++ b/src/Debugger/History.elm
@@ -353,7 +353,7 @@ styles =
   cursor: pointer;
   width: 100%;
   box-sizing: border-box;
-  padding: 4px;
+  padding: 8px;
 }
 
 .elm-debugger-entry:hover {
@@ -362,11 +362,6 @@ styles =
 
 .elm-debugger-entry-selected, .elm-debugger-entry-selected:hover {
   background-color: rgb(10, 10, 10);
-}
-
-.elm-debugger-entry-arrow {
-  display: inline-block;
-  width: 10px;
 }
 
 .elm-debugger-entry-content {
@@ -381,7 +376,7 @@ styles =
 
 .elm-debugger-entry-index {
   color: #666;
-  width: 20px;
+  width: 40px;
   text-align: right;
   display: block;
   float: right;

--- a/src/Debugger/History.elm
+++ b/src/Debugger/History.elm
@@ -32,7 +32,7 @@ import Set exposing (Set)
 
 maxSnapshotSize : Int
 maxSnapshotSize =
-    64
+    31
 
 
 

--- a/src/Debugger/History.elm
+++ b/src/Debugger/History.elm
@@ -320,9 +320,7 @@ viewMessage currentIndex index msg =
         , class className
         , onClick index
         ]
-        [ span [ class "elm-debugger-entry-arrow" ]
-            [ text "" ]
-        , span
+        [ span
             [ title messageName
             , class "elm-debugger-entry-content"
             ]

--- a/src/Debugger/History.elm
+++ b/src/Debugger/History.elm
@@ -230,9 +230,6 @@ view maybeIndex { snapshots, recent, numMessages } =
                 Just i ->
                     ( True, i, "calc(100% - 78px)" )
 
-        highIndex =
-            maxSnapshotSize * Array.length snapshots
-
         onlyRenderRecentMessages =
             isPaused || Array.length snapshots < 2
 
@@ -243,9 +240,12 @@ view maybeIndex { snapshots, recent, numMessages } =
             else
                 lazy3 viewRecentSnapshots index recent.numMessages snapshots
 
+        recentMessageStartIndex =
+            maxSnapshotSize * Array.length snapshots
+
         newStuff =
             recent.messages
-                |> List.foldr (consMsg index) ( highIndex, [] )
+                |> List.foldr (consMsg index) ( recentMessageStartIndex, [] )
                 |> Tuple.second
                 |> Html.Keyed.node "div" []
     in
@@ -262,7 +262,7 @@ view maybeIndex { snapshots, recent, numMessages } =
                     []
 
                 else
-                    [ showMoreButton (numMessages - 1 - maxSnapshotSize * 2) ]
+                    [ showMoreButton numMessages ]
                )
         )
 
@@ -375,10 +375,13 @@ viewMessage currentIndex index msg =
 
 
 showMoreButton : Int -> Html Int
-showMoreButton nextIndex =
+showMoreButton numMessages =
     let
         labelText =
             "View more messages"
+
+        nextIndex =
+            numMessages - 1 - maxSnapshotSize * 2
     in
     div
         [ class "elm-debugger-entry"

--- a/src/Debugger/History.elm
+++ b/src/Debugger/History.elm
@@ -32,6 +32,16 @@ import Set exposing (Set)
 
 maxSnapshotSize : Int
 maxSnapshotSize =
+    -- NOTE: While the app is running we display (maxSnapshotSize * 2) messages
+    -- in the message panel. We want to keep this number relatively low to reduce
+    -- the number of DOM nodes the browser have to deal with. However, we want
+    -- this number to be high to retain as few model snapshots as possible to
+    -- reduce memory usage.
+    --
+    -- 31 is selected because 62 messages fills up the height of a 27 inch monitor,
+    -- with the current style, while avoiding a tree representation in Elm arrays.
+    --
+    -- Performance and memory use seems good.
     31
 
 
@@ -217,11 +227,11 @@ undone getResult =
             ( model, msg )
 
         Stepping _ _ ->
+            -- Debug.crash "Bug in History.get"
             undone getResult
 
 
 
--- Debug.crash "Bug in History.get"
 -- VIEW
 
 

--- a/src/Debugger/History.elm
+++ b/src/Debugger/History.elm
@@ -1,25 +1,24 @@
 module Debugger.History exposing
-  ( History
-  , empty
-  , size
-  , getInitialModel
-  , add
-  , get
-  , view
-  , decoder
-  , encode
-  )
-
+    ( History
+    , add
+    , decoder
+    , empty
+    , encode
+    , get
+    , getInitialModel
+    , size
+    , view
+    )
 
 import Array exposing (Array)
+import Debugger.Metadata as Metadata
 import Elm.Kernel.Debugger
-import Json.Decode as Decode
-import Json.Encode as Encode
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
 import Html.Lazy exposing (..)
-import Debugger.Metadata as Metadata
+import Json.Decode as Decode
+import Json.Encode as Encode
 
 
 
@@ -28,7 +27,7 @@ import Debugger.Metadata as Metadata
 
 maxSnapshotSize : Int
 maxSnapshotSize =
-  64
+    64
 
 
 
@@ -36,85 +35,85 @@ maxSnapshotSize =
 
 
 type alias History model msg =
-  { snapshots : Array (Snapshot model msg)
-  , recent : RecentHistory model msg
-  , numMessages : Int
-  }
+    { snapshots : Array (Snapshot model msg)
+    , recent : RecentHistory model msg
+    , numMessages : Int
+    }
 
 
 type alias RecentHistory model msg =
-  { model : model
-  , messages : List msg
-  , numMessages : Int
-  }
+    { model : model
+    , messages : List msg
+    , numMessages : Int
+    }
 
 
 type alias Snapshot model msg =
-  { model : model
-  , messages : Array msg
-  }
+    { model : model
+    , messages : Array msg
+    }
 
 
 empty : model -> History model msg
 empty model =
-  History Array.empty (RecentHistory model [] 0) 0
+    History Array.empty (RecentHistory model [] 0) 0
 
 
 size : History model msg -> Int
 size history =
-  history.numMessages
+    history.numMessages
 
 
 getInitialModel : History model msg -> model
-getInitialModel  { snapshots, recent } =
-  case Array.get 0 snapshots of
-    Just { model } ->
-      model
+getInitialModel { snapshots, recent } =
+    case Array.get 0 snapshots of
+        Just { model } ->
+            model
 
-    Nothing ->
-      recent.model
+        Nothing ->
+            recent.model
 
 
 
 -- JSON
 
 
-decoder : model -> (msg -> model -> model) -> Decode.Decoder (model, History model msg)
+decoder : model -> (msg -> model -> model) -> Decode.Decoder ( model, History model msg )
 decoder initialModel update =
-  let
-    addMessage rawMsg (model, history) =
-      let
-        msg =
-          jsToElm rawMsg
-      in
-        (update msg model, add msg model history)
+    let
+        addMessage rawMsg ( model, history ) =
+            let
+                msg =
+                    jsToElm rawMsg
+            in
+            ( update msg model, add msg model history )
 
-    updateModel rawMsgs =
-      List.foldl addMessage (initialModel, empty initialModel) rawMsgs
-  in
+        updateModel rawMsgs =
+            List.foldl addMessage ( initialModel, empty initialModel ) rawMsgs
+    in
     Decode.map updateModel (Decode.list Decode.value)
 
 
 jsToElm : Encode.Value -> a
 jsToElm =
-  Elm.Kernel.Json.unwrap
-    >> Elm.Kernel.Debugger.unsafeCoerce
+    Elm.Kernel.Json.unwrap
+        >> Elm.Kernel.Debugger.unsafeCoerce
 
 
 encode : History model msg -> Encode.Value
 encode { snapshots, recent } =
-  Encode.list elmToJs <| Array.foldr encodeHelp (List.reverse recent.messages) snapshots
+    Encode.list elmToJs <| Array.foldr encodeHelp (List.reverse recent.messages) snapshots
 
 
 encodeHelp : Snapshot model msg -> List msg -> List msg
 encodeHelp snapshot allMessages =
-  Array.foldl (::) allMessages snapshot.messages
+    Array.foldl (::) allMessages snapshot.messages
 
 
 elmToJs : a -> Encode.Value
 elmToJs =
-  Elm.Kernel.Json.wrap
-    >> Elm.Kernel.Debugger.unsafeCoerce
+    Elm.Kernel.Json.wrap
+        >> Elm.Kernel.Debugger.unsafeCoerce
 
 
 
@@ -123,115 +122,117 @@ elmToJs =
 
 add : msg -> model -> History model msg -> History model msg
 add msg model { snapshots, recent, numMessages } =
-  case addRecent msg model recent of
-    (Just snapshot, newRecent) ->
-      History (Array.push snapshot snapshots) newRecent (numMessages + 1)
+    case addRecent msg model recent of
+        ( Just snapshot, newRecent ) ->
+            History (Array.push snapshot snapshots) newRecent (numMessages + 1)
 
-    (Nothing, newRecent) ->
-      History snapshots newRecent (numMessages + 1)
+        ( Nothing, newRecent ) ->
+            History snapshots newRecent (numMessages + 1)
 
 
-addRecent
-  : msg
-  -> model
-  -> RecentHistory model msg
-  -> ( Maybe (Snapshot model msg), RecentHistory model msg )
+addRecent :
+    msg
+    -> model
+    -> RecentHistory model msg
+    -> ( Maybe (Snapshot model msg), RecentHistory model msg )
 addRecent msg newModel { model, messages, numMessages } =
-  if numMessages == maxSnapshotSize then
-    ( Just (Snapshot model (Array.fromList messages))
-    , RecentHistory newModel [msg] 1
-    )
+    if numMessages == maxSnapshotSize then
+        ( Just (Snapshot model (Array.fromList messages))
+        , RecentHistory newModel [ msg ] 1
+        )
 
-  else
-    ( Nothing
-    , RecentHistory model (msg :: messages) (numMessages + 1)
-    )
+    else
+        ( Nothing
+        , RecentHistory model (msg :: messages) (numMessages + 1)
+        )
 
 
 
 -- GET SUMMARY
 
 
-get : (msg -> model -> (model, a)) -> Int -> History model msg -> ( model, msg )
+get : (msg -> model -> ( model, a )) -> Int -> History model msg -> ( model, msg )
 get update index history =
-  let
-    recent =
-      history.recent
+    let
+        recent =
+            history.recent
 
-    snapshotMax =
-      history.numMessages - recent.numMessages
-  in
+        snapshotMax =
+            history.numMessages - recent.numMessages
+    in
     if index >= snapshotMax then
-      undone <|
-        List.foldr (getHelp update) (Stepping (index - snapshotMax) recent.model) recent.messages
+        undone <|
+            List.foldr (getHelp update) (Stepping (index - snapshotMax) recent.model) recent.messages
 
     else
-      case Array.get (index // maxSnapshotSize) history.snapshots of
-        Nothing ->
-          get update index history
-          -- Debug.crash "UI should only let you ask for real indexes!"
+        case Array.get (index // maxSnapshotSize) history.snapshots of
+            Nothing ->
+                get update index history
 
-        Just { model, messages } ->
-          undone <|
-            Array.foldr (getHelp update) (Stepping (remainderBy maxSnapshotSize index) model) messages
+            -- Debug.crash "UI should only let you ask for real indexes!"
+            Just { model, messages } ->
+                undone <|
+                    Array.foldr (getHelp update) (Stepping (remainderBy maxSnapshotSize index) model) messages
 
 
 type GetResult model msg
-  = Stepping Int model
-  | Done msg model
+    = Stepping Int model
+    | Done msg model
 
 
-getHelp : (msg -> model -> (model, a)) -> msg -> GetResult model msg -> GetResult model msg
+getHelp : (msg -> model -> ( model, a )) -> msg -> GetResult model msg -> GetResult model msg
 getHelp update msg getResult =
-  case getResult of
-    Done _ _ ->
-      getResult
+    case getResult of
+        Done _ _ ->
+            getResult
 
-    Stepping n model ->
-      if n == 0 then
-        Done msg (Tuple.first (update msg model))
+        Stepping n model ->
+            if n == 0 then
+                Done msg (Tuple.first (update msg model))
 
-      else
-        Stepping (n - 1) (Tuple.first (update msg model))
+            else
+                Stepping (n - 1) (Tuple.first (update msg model))
 
 
 undone : GetResult model msg -> ( model, msg )
 undone getResult =
-  case getResult of
-    Done msg model ->
-      ( model, msg )
+    case getResult of
+        Done msg model ->
+            ( model, msg )
 
-    Stepping _ _ ->
-      undone getResult -- Debug.crash "Bug in History.get"
+        Stepping _ _ ->
+            undone getResult
 
 
 
+-- Debug.crash "Bug in History.get"
 -- VIEW
 
 
 view : Maybe Int -> History model msg -> Html Int
 view maybeIndex { snapshots, recent, numMessages } =
-  let
-    (index, height) =
-      case maybeIndex of
-        Nothing ->
-          ( -1, "calc(100% - 24px)" )
-        Just i ->
-          ( i, "calc(100% - 54px)" )
+    let
+        ( index, height ) =
+            case maybeIndex of
+                Nothing ->
+                    ( -1, "calc(100% - 24px)" )
 
-    oldStuff =
-      lazy2 viewSnapshots index snapshots
+                Just i ->
+                    ( i, "calc(100% - 54px)" )
 
-    newStuff =
-      Tuple.second <| List.foldl (consMsg index) (numMessages - 1, []) recent.messages
-  in
+        oldStuff =
+            lazy2 viewSnapshots index snapshots
+
+        newStuff =
+            Tuple.second <| List.foldl (consMsg index) ( numMessages - 1, [] ) recent.messages
+    in
     div
-      [ id "elm-debugger-sidebar"
-      , style "width" "100%"
-      , style "overflow-y" "auto"
-      , style "height" height
-      ]
-      (styles :: oldStuff :: newStuff)
+        [ id "elm-debugger-sidebar"
+        , style "width" "100%"
+        , style "overflow-y" "auto"
+        , style "height" height
+        ]
+        (styles :: oldStuff :: newStuff)
 
 
 
@@ -240,23 +241,28 @@ view maybeIndex { snapshots, recent, numMessages } =
 
 viewSnapshots : Int -> Array (Snapshot model msg) -> Html Int
 viewSnapshots currentIndex snapshots =
-  let
-    highIndex =
-      maxSnapshotSize * Array.length snapshots
-  in
-    div [] <| Tuple.second <|
-      Array.foldr (consSnapshot currentIndex) (highIndex, []) snapshots
+    let
+        highIndex =
+            maxSnapshotSize * Array.length snapshots
+    in
+    div [] <|
+        Tuple.second <|
+            Array.foldr (consSnapshot currentIndex) ( highIndex, [] ) snapshots
 
 
 consSnapshot : Int -> Snapshot model msg -> ( Int, List (Html Int) ) -> ( Int, List (Html Int) )
-consSnapshot currentIndex snapshot (index, rest) =
-  let
-    nextIndex =
-      index - maxSnapshotSize
+consSnapshot currentIndex snapshot ( index, rest ) =
+    let
+        nextIndex =
+            index - maxSnapshotSize
 
-    currentIndexHelp =
-      if nextIndex <= currentIndex && currentIndex < index then currentIndex else -1
-  in
+        currentIndexHelp =
+            if nextIndex <= currentIndex && currentIndex < index then
+                currentIndex
+
+            else
+                -1
+    in
     ( index - maxSnapshotSize
     , lazy3 viewSnapshot currentIndexHelp index snapshot :: rest
     )
@@ -264,8 +270,9 @@ consSnapshot currentIndex snapshot (index, rest) =
 
 viewSnapshot : Int -> Int -> Snapshot model msg -> Html Int
 viewSnapshot currentIndex index { messages } =
-  div [] <| Tuple.second <|
-    Array.foldl (consMsg currentIndex) (index - 1, []) messages
+    div [] <|
+        Tuple.second <|
+            Array.foldl (consMsg currentIndex) ( index - 1, [] ) messages
 
 
 
@@ -273,40 +280,41 @@ viewSnapshot currentIndex index { messages } =
 
 
 consMsg : Int -> msg -> ( Int, List (Html Int) ) -> ( Int, List (Html Int) )
-consMsg currentIndex msg (index, rest) =
-  ( index - 1
-  , lazy3 viewMessage currentIndex index msg :: rest
-  )
+consMsg currentIndex msg ( index, rest ) =
+    ( index - 1
+    , lazy3 viewMessage currentIndex index msg :: rest
+    )
 
 
 viewMessage : Int -> Int -> msg -> Html Int
 viewMessage currentIndex index msg =
-  let
-    className =
-      if currentIndex == index then
-        "elm-debugger-entry elm-debugger-entry-selected"
-      else
-        "elm-debugger-entry"
+    let
+        className =
+            if currentIndex == index then
+                "elm-debugger-entry elm-debugger-entry-selected"
 
-    messageName =
-      Elm.Kernel.Debugger.messageToString msg
-  in
-  div
-    [ class className
-    , onClick index
-    ]
-    [ span
-        [ title messageName
-        , class "elm-debugger-entry-content"
+            else
+                "elm-debugger-entry"
+
+        messageName =
+            Elm.Kernel.Debugger.messageToString msg
+    in
+    div
+        [ class className
+        , onClick index
         ]
-        [ text messageName
+        [ span
+            [ title messageName
+            , class "elm-debugger-entry-content"
+            ]
+            [ text messageName
+            ]
+        , span
+            [ class "elm-debugger-entry-index"
+            ]
+            [ text (String.fromInt index)
+            ]
         ]
-    , span
-        [ class "elm-debugger-entry-index"
-        ]
-        [ text (String.fromInt index)
-        ]
-    ]
 
 
 
@@ -315,7 +323,7 @@ viewMessage currentIndex index msg =
 
 styles : Html msg
 styles =
-  Html.node "style" [] [ text """
+    Html.node "style" [] [ text """
 
 .elm-debugger-entry {
   cursor: pointer;

--- a/src/Debugger/History.elm
+++ b/src/Debugger/History.elm
@@ -2,14 +2,11 @@ module Debugger.History exposing
     ( History
     , Msg(..)
     , add
-    , addLog
-    , clearLogs
     , decoder
     , empty
     , encode
     , get
     , getInitialModel
-    , getLogs
     , getRecent
     , openMultiContainer
     , size
@@ -19,7 +16,6 @@ module Debugger.History exposing
 import Array exposing (Array)
 import Debugger.Expando as Expando exposing (Expando)
 import Debugger.Metadata as Metadata
-import Dict exposing (Dict)
 import Elm.Kernel.Debugger
 import Html exposing (..)
 import Html.Attributes exposing (..)
@@ -48,7 +44,6 @@ type alias History model msg =
     , recent : RecentHistory model msg
     , numMessages : Int
     , messageHierarchy : MsgHierarchy msg
-    , logs : Dict String Expando
     }
 
 
@@ -79,7 +74,7 @@ type MsgContainer msg
 
 empty : model -> History model msg
 empty model =
-    History Array.empty (RecentHistory model [] 0) 0 emptyHierarchy Dict.empty
+    History Array.empty (RecentHistory model [] 0) 0 emptyHierarchy
 
 
 emptyHierarchy : MsgHierarchy msg
@@ -255,13 +250,13 @@ elmToJs =
 
 
 add : msg -> model -> History model msg -> History model msg
-add msg model { snapshots, recent, numMessages, messageHierarchy, logs } =
+add msg model { snapshots, recent, numMessages, messageHierarchy } =
     case addRecent msg model recent of
         ( Just snapshot, newRecent ) ->
-            History (Array.push snapshot snapshots) newRecent (numMessages + 1) (addToHierarchy msg messageHierarchy) logs
+            History (Array.push snapshot snapshots) newRecent (numMessages + 1) (addToHierarchy msg messageHierarchy)
 
         ( Nothing, newRecent ) ->
-            History snapshots newRecent (numMessages + 1) (addToHierarchy msg messageHierarchy) logs
+            History snapshots newRecent (numMessages + 1) (addToHierarchy msg messageHierarchy)
 
 
 addRecent :
@@ -279,12 +274,6 @@ addRecent msg newModel { model, messages, numMessages } =
         ( Nothing
         , RecentHistory model (msg :: messages) (numMessages + 1)
         )
-
-
-addLog : String -> a -> History model msg -> History model msg
-addLog label value { snapshots, recent, numMessages, messageHierarchy, logs } =
-    History snapshots recent numMessages messageHierarchy <|
-        Dict.insert label (Expando.init value) logs
 
 
 
@@ -337,16 +326,6 @@ getHelp update msg getResult =
 
             else
                 Stepping (n - 1) (Tuple.first (update msg model))
-
-
-getLogs : Int -> History model msg -> Dict String Expando
-getLogs index history =
-    history.logs
-
-
-clearLogs : History model msg -> History model msg
-clearLogs { snapshots, recent, numMessages, messageHierarchy, logs } =
-    History snapshots recent numMessages messageHierarchy Dict.empty
 
 
 undone : GetResult model msg -> ( model, msg )

--- a/src/Debugger/History.elm
+++ b/src/Debugger/History.elm
@@ -112,7 +112,8 @@ encodeHelp snapshot allMessages =
 
 elmToJs : a -> Encode.Value
 elmToJs =
-  Elm.Kernel.Debugger.unsafeCoerce
+  Elm.Kernel.Json.wrap
+    >> Elm.Kernel.Debugger.unsafeCoerce
 
 
 

--- a/src/Debugger/History.elm
+++ b/src/Debugger/History.elm
@@ -222,7 +222,7 @@ undone getResult =
 view : Maybe Int -> History model msg -> Html Int
 view maybeIndex { snapshots, recent, numMessages } =
     let
-        ( renderAllMessages, index, height ) =
+        ( isPaused, index, height ) =
             case maybeIndex of
                 Nothing ->
                     ( False, -1, "calc(100% - 48px)" )
@@ -233,8 +233,11 @@ view maybeIndex { snapshots, recent, numMessages } =
         highIndex =
             maxSnapshotSize * Array.length snapshots
 
+        onlyRenderRecentMessages =
+            isPaused || Array.length snapshots < 2
+
         oldStuff =
-            if renderAllMessages || Array.length snapshots < 2 then
+            if onlyRenderRecentMessages then
                 lazy3 viewAllSnapshots index 0 snapshots
 
             else
@@ -252,10 +255,16 @@ view maybeIndex { snapshots, recent, numMessages } =
         , style "overflow-y" "auto"
         , style "height" height
         ]
-        [ styles
-        , newStuff
-        , oldStuff
-        ]
+        (styles
+            :: newStuff
+            :: oldStuff
+            :: (if onlyRenderRecentMessages then
+                    []
+
+                else
+                    [ showMoreButton (numMessages - 1 - maxSnapshotSize * 2) ]
+               )
+        )
 
 
 
@@ -362,6 +371,29 @@ viewMessage currentIndex index msg =
             ]
             [ text (String.fromInt index)
             ]
+        ]
+
+
+showMoreButton : Int -> Html Int
+showMoreButton nextIndex =
+    let
+        labelText =
+            "View more messages"
+    in
+    div
+        [ class "elm-debugger-entry"
+        , onClick nextIndex
+        ]
+        [ span
+            [ title labelText
+            , class "elm-debugger-entry-content"
+            ]
+            [ text labelText
+            ]
+        , span
+            [ class "elm-debugger-entry-index"
+            ]
+            []
         ]
 
 

--- a/src/Debugger/History.elm
+++ b/src/Debugger/History.elm
@@ -6,6 +6,7 @@ module Debugger.History exposing
     , encode
     , get
     , getInitialModel
+    , getRecent
     , size
     , view
     )
@@ -173,6 +174,18 @@ get update index history =
             Just { model, messages } ->
                 undone <|
                     Array.foldr (getHelp update) (Stepping (remainderBy maxSnapshotSize index) model) messages
+
+
+getRecent : History model msg -> ( model, msg )
+getRecent history =
+    case history.recent.messages of
+        [] ->
+            getRecent history
+
+        recentMsg :: _ ->
+            ( history.recent.model
+            , recentMsg
+            )
 
 
 type GetResult model msg

--- a/src/Debugger/History.elm
+++ b/src/Debugger/History.elm
@@ -97,7 +97,8 @@ decoder initialModel update =
 
 jsToElm : Encode.Value -> a
 jsToElm =
-  Elm.Kernel.Debugger.unsafeCoerce
+  Elm.Kernel.Json.unwrap
+    >> Elm.Kernel.Debugger.unsafeCoerce
 
 
 encode : History model msg -> Encode.Value

--- a/src/Debugger/Main.elm
+++ b/src/Debugger/Main.elm
@@ -147,6 +147,7 @@ type Msg msg
     | ExpandoMsg ExpandoTarget Expando.Msg
     | Resume
     | Jump Int
+    | SliderJump Int
     | Open
     | Up
     | Down
@@ -278,6 +279,15 @@ wrapUpdate update msg model =
             , Cmd.none
             )
 
+        SliderJump index ->
+            let
+                ( modelAfterJump, jumpCmds ) =
+                    wrapUpdate update (Jump index) model
+            in
+            ( modelAfterJump
+            , scrollTo (History.idForMessageIndex index) model.popout
+            )
+
         Open ->
             ( model
             , Task.perform (\_ -> NoOp) (Elm.Kernel.Debugger.open model.popout)
@@ -383,6 +393,11 @@ wrapUpdate update msg model =
 scroll : Popout -> Cmd (Msg msg)
 scroll popout =
     Task.perform (always NoOp) (Elm.Kernel.Debugger.scroll popout)
+
+
+scrollTo : String -> Popout -> Cmd (Msg msg)
+scrollTo id popout =
+    Task.perform (always NoOp) (Elm.Kernel.Debugger.scrollTo id popout)
 
 
 upload : Popout -> Cmd (Msg msg)
@@ -702,7 +717,7 @@ slider history maybeIndex =
             , Html.Attributes.min "0"
             , Html.Attributes.max (String.fromInt lastIndex)
             , value (String.fromInt selectedIndex)
-            , onInput (String.toInt >> Maybe.withDefault lastIndex >> Jump)
+            , onInput (String.toInt >> Maybe.withDefault lastIndex >> SliderJump)
             ]
             []
         ]

--- a/src/Debugger/Main.elm
+++ b/src/Debugger/Main.elm
@@ -305,31 +305,31 @@ wrapUpdate update msg model =
 
         Up ->
             let
-                index =
+                ( index, history ) =
                     case model.state of
-                        Paused i _ _ _ _ ->
-                            i
+                        Paused i _ _ _ cachedHistory ->
+                            ( i + 1, cachedHistory )
 
                         Running _ ->
-                            History.size model.history
+                            ( 0, model.history )
             in
-            if index > 0 then
-                wrapUpdate update (Jump (index - 1)) model
+            if index < History.size history then
+                wrapUpdate update (Jump index) model
 
             else
-                ( model, Cmd.none )
+                wrapUpdate update Resume model
 
         Down ->
             case model.state of
                 Running _ ->
-                    ( model, Cmd.none )
+                    wrapUpdate update (Jump (History.size model.history - 1)) model
 
                 Paused index _ userModel userMsg _ ->
-                    if index == History.size model.history - 1 then
-                        wrapUpdate update Resume model
+                    if index > 0 then
+                        wrapUpdate update (Jump (index - 1)) model
 
                     else
-                        wrapUpdate update (Jump (index + 1)) model
+                        ( model, Cmd.none )
 
         EnableSidePanelResizing enabled ->
             ( { model | sidePanelResizable = enabled }

--- a/src/Debugger/Main.elm
+++ b/src/Debugger/Main.elm
@@ -1,25 +1,24 @@
 module Debugger.Main exposing
-  ( wrapInit
-  , wrapUpdate
-  , wrapSubs
-  , getUserModel
-  , cornerView
-  , popoutView
-  )
+    ( cornerView
+    , getUserModel
+    , popoutView
+    , wrapInit
+    , wrapSubs
+    , wrapUpdate
+    )
 
-
-import Elm.Kernel.Debugger
-import Json.Decode as Decode
-import Json.Encode as Encode
-import Html exposing (..)
-import Html.Attributes exposing (..)
-import Html.Events exposing (onClick)
-import Task exposing (Task)
 import Debugger.Expando as Expando exposing (Expando)
 import Debugger.History as History exposing (History)
 import Debugger.Metadata as Metadata exposing (Metadata)
 import Debugger.Overlay as Overlay
 import Debugger.Report as Report
+import Elm.Kernel.Debugger
+import Html exposing (..)
+import Html.Attributes exposing (..)
+import Html.Events exposing (onClick)
+import Json.Decode as Decode
+import Json.Encode as Encode
+import Task exposing (Task)
 
 
 
@@ -28,7 +27,7 @@ import Debugger.Report as Report
 
 getUserModel : Model model msg -> model
 getUserModel model =
-  getCurrentModel model.state
+    getCurrentModel model.state
 
 
 
@@ -37,7 +36,7 @@ getUserModel model =
 
 wrapSubs : (model -> Sub msg) -> Model model msg -> Sub (Msg msg)
 wrapSubs subscriptions model =
-  Sub.map UserMsg (subscriptions (getLatestModel model.state))
+    Sub.map UserMsg (subscriptions (getLatestModel model.state))
 
 
 
@@ -45,16 +44,17 @@ wrapSubs subscriptions model =
 
 
 type alias Model model msg =
-  { history : History model msg
-  , state : State model
-  , expando : Expando
-  , metadata : Result Metadata.Error Metadata
-  , overlay : Overlay.State
-  , popout : Popout
-  }
+    { history : History model msg
+    , state : State model
+    , expando : Expando
+    , metadata : Result Metadata.Error Metadata
+    , overlay : Overlay.State
+    , popout : Popout
+    }
 
 
-type Popout = Popout Popout
+type Popout
+    = Popout Popout
 
 
 
@@ -62,59 +62,59 @@ type Popout = Popout Popout
 
 
 type State model
-  = Running model
-  | Paused Int model model
+    = Running model
+    | Paused Int model model
 
 
 getLatestModel : State model -> model
 getLatestModel state =
-  case state of
-    Running model ->
-      model
+    case state of
+        Running model ->
+            model
 
-    Paused _ _ model ->
-      model
+        Paused _ _ model ->
+            model
 
 
 getCurrentModel : State model -> model
 getCurrentModel state =
-  case state of
-    Running model ->
-      model
+    case state of
+        Running model ->
+            model
 
-    Paused _ model _ ->
-      model
+        Paused _ model _ ->
+            model
 
 
 isPaused : State model -> Bool
 isPaused state =
-  case state of
-    Running _ ->
-      False
+    case state of
+        Running _ ->
+            False
 
-    Paused _ _ _ ->
-      True
+        Paused _ _ _ ->
+            True
 
 
 
 -- INIT
 
 
-wrapInit : Encode.Value -> Popout -> (flags -> (model, Cmd msg)) -> flags -> (Model model msg, Cmd (Msg msg))
+wrapInit : Encode.Value -> Popout -> (flags -> ( model, Cmd msg )) -> flags -> ( Model model msg, Cmd (Msg msg) )
 wrapInit metadata popout init flags =
-  let
-    (userModel, userCommands) =
-      init flags
-  in
-  ( { history = History.empty userModel
-    , state = Running userModel
-    , expando = Expando.init userModel
-    , metadata = Metadata.decode metadata
-    , overlay = Overlay.none
-    , popout = popout
-    }
-  , Cmd.map UserMsg userCommands
-  )
+    let
+        ( userModel, userCommands ) =
+            init flags
+    in
+    ( { history = History.empty userModel
+      , state = Running userModel
+      , expando = Expando.init userModel
+      , metadata = Metadata.decode metadata
+      , overlay = Overlay.none
+      , popout = popout
+      }
+    , Cmd.map UserMsg userCommands
+    )
 
 
 
@@ -122,140 +122,152 @@ wrapInit metadata popout init flags =
 
 
 type Msg msg
-  = NoOp
-  | UserMsg msg
-  | ExpandoMsg Expando.Msg
-  | Resume
-  | Jump Int
-  | Open
-  | Up
-  | Down
-  | Import
-  | Export
-  | Upload String
-  | OverlayMsg Overlay.Msg
+    = NoOp
+    | UserMsg msg
+    | ExpandoMsg Expando.Msg
+    | Resume
+    | Jump Int
+    | Open
+    | Up
+    | Down
+    | Import
+    | Export
+    | Upload String
+    | OverlayMsg Overlay.Msg
 
 
 type alias UserUpdate model msg =
-  msg -> model -> ( model, Cmd msg )
+    msg -> model -> ( model, Cmd msg )
 
 
-wrapUpdate : UserUpdate model msg -> Msg msg -> Model model msg -> (Model model msg, Cmd (Msg msg))
+wrapUpdate : UserUpdate model msg -> Msg msg -> Model model msg -> ( Model model msg, Cmd (Msg msg) )
 wrapUpdate update msg model =
-  case msg of
-    NoOp ->
-      ( model, Cmd.none )
+    case msg of
+        NoOp ->
+            ( model, Cmd.none )
 
-    UserMsg userMsg ->
-      let
-        userModel = getLatestModel model.state
-        newHistory = History.add userMsg userModel model.history
-        (newUserModel, userCmds) = update userMsg userModel
-        commands = Cmd.map UserMsg userCmds
-      in
-      case model.state of
-        Running _ ->
-          ( { model
-              | history = newHistory
-              , state = Running newUserModel
-              , expando = Expando.merge newUserModel model.expando
-            }
-          , Cmd.batch [ commands, scroll model.popout ]
-          )
+        UserMsg userMsg ->
+            let
+                userModel =
+                    getLatestModel model.state
 
-        Paused index indexModel _ ->
-          ( { model
-              | history = newHistory
-              , state = Paused index indexModel newUserModel
-            }
-          , commands
-          )
+                newHistory =
+                    History.add userMsg userModel model.history
 
-    ExpandoMsg eMsg ->
-      ( { model | expando = Expando.update eMsg model.expando }
-      , Cmd.none
-      )
+                ( newUserModel, userCmds ) =
+                    update userMsg userModel
 
-    Resume ->
-      case model.state of
-        Running _ ->
-          ( model, Cmd.none )
+                commands =
+                    Cmd.map UserMsg userCmds
+            in
+            case model.state of
+                Running _ ->
+                    ( { model
+                        | history = newHistory
+                        , state = Running newUserModel
+                        , expando = Expando.merge newUserModel model.expando
+                      }
+                    , Cmd.batch [ commands, scroll model.popout ]
+                    )
 
-        Paused _ _ userModel ->
-          ( { model
-              | state = Running userModel
-              , expando = Expando.merge userModel model.expando
-            }
-          , scroll model.popout
-          )
+                Paused index indexModel _ ->
+                    ( { model
+                        | history = newHistory
+                        , state = Paused index indexModel newUserModel
+                      }
+                    , commands
+                    )
 
-    Jump index ->
-      let
-        (indexModel, indexMsg) =
-          History.get update index model.history
-      in
-      ( { model
-          | state = Paused index indexModel (getLatestModel model.state)
-          , expando = Expando.merge indexModel model.expando
-        }
-      , Cmd.none
-      )
+        ExpandoMsg eMsg ->
+            ( { model | expando = Expando.update eMsg model.expando }
+            , Cmd.none
+            )
 
-    Open ->
-      ( model
-      , Task.perform (\_ -> NoOp) (Elm.Kernel.Debugger.open model.popout)
-      )
+        Resume ->
+            case model.state of
+                Running _ ->
+                    ( model, Cmd.none )
 
-    Up ->
-      let
-        index =
-          case model.state of
-            Paused i _ _ ->
-              i
+                Paused _ _ userModel ->
+                    ( { model
+                        | state = Running userModel
+                        , expando = Expando.merge userModel model.expando
+                      }
+                    , scroll model.popout
+                    )
 
-            Running _ ->
-              History.size model.history
-      in
-      if index > 0 then
-        wrapUpdate update (Jump (index - 1)) model
-      else
-        ( model, Cmd.none )
+        Jump index ->
+            let
+                ( indexModel, indexMsg ) =
+                    History.get update index model.history
+            in
+            ( { model
+                | state = Paused index indexModel (getLatestModel model.state)
+                , expando = Expando.merge indexModel model.expando
+              }
+            , Cmd.none
+            )
 
-    Down ->
-      case model.state of
-        Running _ ->
-          ( model, Cmd.none )
+        Open ->
+            ( model
+            , Task.perform (\_ -> NoOp) (Elm.Kernel.Debugger.open model.popout)
+            )
 
-        Paused index _ userModel ->
-          if index == History.size model.history - 1 then
-            wrapUpdate update Resume model
-          else
-            wrapUpdate update (Jump (index + 1)) model
+        Up ->
+            let
+                index =
+                    case model.state of
+                        Paused i _ _ ->
+                            i
 
-    Import ->
-      withGoodMetadata model <| \_ ->
-        ( model, upload model.popout )
+                        Running _ ->
+                            History.size model.history
+            in
+            if index > 0 then
+                wrapUpdate update (Jump (index - 1)) model
 
-    Export ->
-      withGoodMetadata model <| \metadata ->
-        ( model, download metadata model.history )
+            else
+                ( model, Cmd.none )
 
-    Upload jsonString ->
-      withGoodMetadata model <| \metadata ->
-        case Overlay.assessImport metadata jsonString of
-          Err newOverlay ->
-            ( { model | overlay = newOverlay }, Cmd.none )
+        Down ->
+            case model.state of
+                Running _ ->
+                    ( model, Cmd.none )
 
-          Ok rawHistory ->
-            loadNewHistory rawHistory update model
+                Paused index _ userModel ->
+                    if index == History.size model.history - 1 then
+                        wrapUpdate update Resume model
 
-    OverlayMsg overlayMsg ->
-      case Overlay.close overlayMsg model.overlay of
-        Nothing ->
-          ( { model | overlay = Overlay.none }, Cmd.none )
+                    else
+                        wrapUpdate update (Jump (index + 1)) model
 
-        Just rawHistory ->
-          loadNewHistory rawHistory update model
+        Import ->
+            withGoodMetadata model <|
+                \_ ->
+                    ( model, upload model.popout )
+
+        Export ->
+            withGoodMetadata model <|
+                \metadata ->
+                    ( model, download metadata model.history )
+
+        Upload jsonString ->
+            withGoodMetadata model <|
+                \metadata ->
+                    case Overlay.assessImport metadata jsonString of
+                        Err newOverlay ->
+                            ( { model | overlay = newOverlay }, Cmd.none )
+
+                        Ok rawHistory ->
+                            loadNewHistory rawHistory update model
+
+        OverlayMsg overlayMsg ->
+            case Overlay.close overlayMsg model.overlay of
+                Nothing ->
+                    ( { model | overlay = Overlay.none }, Cmd.none )
+
+                Just rawHistory ->
+                    loadNewHistory rawHistory update model
 
 
 
@@ -264,27 +276,27 @@ wrapUpdate update msg model =
 
 scroll : Popout -> Cmd (Msg msg)
 scroll popout =
-  Task.perform (always NoOp) (Elm.Kernel.Debugger.scroll popout)
+    Task.perform (always NoOp) (Elm.Kernel.Debugger.scroll popout)
 
 
 upload : Popout -> Cmd (Msg msg)
 upload popout =
-  Task.perform Upload (Elm.Kernel.Debugger.upload popout)
+    Task.perform Upload (Elm.Kernel.Debugger.upload popout)
 
 
 download : Metadata -> History model msg -> Cmd (Msg msg)
 download metadata history =
-  let
-    historyLength =
-      History.size history
+    let
+        historyLength =
+            History.size history
 
-    json =
-      Encode.object
-        [ ("metadata", Metadata.encode metadata)
-        , ("history", History.encode history)
-        ]
-        |> Elm.Kernel.Json.unwrap
-  in
+        json =
+            Encode.object
+                [ ( "metadata", Metadata.encode metadata )
+                , ( "history", History.encode history )
+                ]
+                |> Elm.Kernel.Json.unwrap
+    in
     Task.perform (\_ -> NoOp) (Elm.Kernel.Debugger.download historyLength json)
 
 
@@ -292,52 +304,52 @@ download metadata history =
 -- UPDATE OVERLAY
 
 
-withGoodMetadata
-  : Model model msg
-  -> (Metadata -> (Model model msg, Cmd (Msg msg)))
-  -> (Model model msg, Cmd (Msg msg))
+withGoodMetadata :
+    Model model msg
+    -> (Metadata -> ( Model model msg, Cmd (Msg msg) ))
+    -> ( Model model msg, Cmd (Msg msg) )
 withGoodMetadata model func =
-  case model.metadata of
-    Ok metadata ->
-      func metadata
+    case model.metadata of
+        Ok metadata ->
+            func metadata
 
-    Err error ->
-      ( { model | overlay = Overlay.badMetadata error }
-      , Cmd.none
-      )
+        Err error ->
+            ( { model | overlay = Overlay.badMetadata error }
+            , Cmd.none
+            )
 
 
-loadNewHistory
-  : Encode.Value
-  -> UserUpdate model msg
-  -> Model model msg
-  -> ( Model model msg, Cmd (Msg msg) )
+loadNewHistory :
+    Encode.Value
+    -> UserUpdate model msg
+    -> Model model msg
+    -> ( Model model msg, Cmd (Msg msg) )
 loadNewHistory rawHistory update model =
-  let
-    initialUserModel =
-      History.getInitialModel model.history
+    let
+        initialUserModel =
+            History.getInitialModel model.history
 
-    pureUserUpdate msg userModel =
-      Tuple.first (update msg userModel)
+        pureUserUpdate msg userModel =
+            Tuple.first (update msg userModel)
 
-    decoder =
-      History.decoder initialUserModel pureUserUpdate
-  in
-  case Decode.decodeValue decoder rawHistory of
-    Err _ ->
-      ( { model | overlay = Overlay.corruptImport }
-      , Cmd.none
-      )
+        decoder =
+            History.decoder initialUserModel pureUserUpdate
+    in
+    case Decode.decodeValue decoder rawHistory of
+        Err _ ->
+            ( { model | overlay = Overlay.corruptImport }
+            , Cmd.none
+            )
 
-    Ok (latestUserModel, newHistory) ->
-      ( { model
-          | history = newHistory
-          , state = Running latestUserModel
-          , expando = Expando.init latestUserModel
-          , overlay = Overlay.none
-        }
-      , Cmd.none
-      )
+        Ok ( latestUserModel, newHistory ) ->
+            ( { model
+                | history = newHistory
+                , state = Running latestUserModel
+                , expando = Expando.init latestUserModel
+                , overlay = Overlay.none
+              }
+            , Cmd.none
+            )
 
 
 
@@ -346,22 +358,22 @@ loadNewHistory rawHistory update model =
 
 cornerView : Model model msg -> Html (Msg msg)
 cornerView model =
-  Overlay.view
-    { resume = Resume
-    , open = Open
-    , importHistory = Import
-    , exportHistory = Export
-    , wrap = OverlayMsg
-    }
-    (isPaused model.state)
-    (Elm.Kernel.Debugger.isOpen model.popout)
-    (History.size model.history)
-    model.overlay
+    Overlay.view
+        { resume = Resume
+        , open = Open
+        , importHistory = Import
+        , exportHistory = Export
+        , wrap = OverlayMsg
+        }
+        (isPaused model.state)
+        (Elm.Kernel.Debugger.isOpen model.popout)
+        (History.size model.history)
+        model.overlay
 
 
 toBlockerType : Model model msg -> Overlay.BlockerType
 toBlockerType model =
-  Overlay.toBlockerType (isPaused model.state) model.overlay
+    Overlay.toBlockerType (isPaused model.state) model.overlay
 
 
 
@@ -370,102 +382,103 @@ toBlockerType model =
 
 popoutView : Model model msg -> Html (Msg msg)
 popoutView { history, state, expando } =
-  node "body"
-    [ style "margin" "0"
-    , style "padding" "0"
-    , style "width" "100%"
-    , style "height" "100%"
-    , style "font-family" "monospace"
-    , style "overflow" "auto"
-    ]
-    [ viewSidebar state history
-    , Html.map ExpandoMsg <|
-        div
-          [ style "display" "block"
-          , style "float" "left"
-          , style "height" "100%"
-          , style "width" "calc(100% - 30ch)"
-          , style "margin" "0"
-          , style "overflow" "auto"
-          , style "cursor" "default"
-          ]
-          [ Expando.view Nothing expando
-          ]
-    ]
+    node "body"
+        [ style "margin" "0"
+        , style "padding" "0"
+        , style "width" "100%"
+        , style "height" "100%"
+        , style "font-family" "monospace"
+        , style "overflow" "auto"
+        ]
+        [ viewSidebar state history
+        , Html.map ExpandoMsg <|
+            div
+                [ style "display" "block"
+                , style "float" "left"
+                , style "height" "100%"
+                , style "width" "calc(100% - 30ch)"
+                , style "margin" "0"
+                , style "overflow" "auto"
+                , style "cursor" "default"
+                ]
+                [ Expando.view Nothing expando
+                ]
+        ]
 
 
 viewSidebar : State model -> History model msg -> Html (Msg msg)
 viewSidebar state history =
-  let
-    maybeIndex =
-      case state of
-        Running _ ->
-          Nothing
+    let
+        maybeIndex =
+            case state of
+                Running _ ->
+                    Nothing
 
-        Paused index _ _ ->
-          Just index
-  in
+                Paused index _ _ ->
+                    Just index
+    in
     div
-      [ style "display" "block"
-      , style "float" "left"
-      , style "width" "30ch"
-      , style "height" "100%"
-      , style "color" "white"
-      , style "background-color" "rgb(61, 61, 61)"
-      ]
-      [ Html.map Jump (History.view maybeIndex history)
-      , playButton maybeIndex
-      ]
+        [ style "display" "block"
+        , style "float" "left"
+        , style "width" "30ch"
+        , style "height" "100%"
+        , style "color" "white"
+        , style "background-color" "rgb(61, 61, 61)"
+        ]
+        [ Html.map Jump (History.view maybeIndex history)
+        , playButton maybeIndex
+        ]
 
 
 playButton : Maybe Int -> Html (Msg msg)
 playButton maybeIndex =
-  div
-    [ style "width" "100%"
-    , style "text-align" "center"
-    , style "background-color" "rgb(50, 50, 50)"
-    ]
-    [ viewResumeButton maybeIndex
-    , div
+    div
         [ style "width" "100%"
-        , style "height" "24px"
-        , style "line-height" "24px"
-        , style "font-size" "12px"
+        , style "text-align" "center"
+        , style "background-color" "rgb(50, 50, 50)"
         ]
-        [ viewTextButton Import "Import"
-        , text " / "
-        , viewTextButton Export "Export"
+        [ viewResumeButton maybeIndex
+        , div
+            [ style "width" "100%"
+            , style "height" "24px"
+            , style "line-height" "24px"
+            , style "font-size" "12px"
+            ]
+            [ viewTextButton Import "Import"
+            , text " / "
+            , viewTextButton Export "Export"
+            ]
         ]
-    ]
 
 
 viewTextButton : msg -> String -> Html msg
 viewTextButton msg label =
-  span
-    [ onClick msg
-    , style "cursor" "pointer"
-    ]
-    [ text label ]
+    span
+        [ onClick msg
+        , style "cursor" "pointer"
+        ]
+        [ text label ]
 
 
 viewResumeButton : Maybe Int -> Html (Msg msg)
 viewResumeButton maybeIndex =
-  case maybeIndex of
-    Nothing ->
-      text ""
+    case maybeIndex of
+        Nothing ->
+            text ""
 
-    Just _ ->
-      div
-        [ onClick Resume
-        , class "elm-debugger-resume"
-        ]
-        [ text "Resume"
-        , Html.node "style" [] [ text resumeStyle ]
-        ]
+        Just _ ->
+            div
+                [ onClick Resume
+                , class "elm-debugger-resume"
+                ]
+                [ text "Resume"
+                , Html.node "style" [] [ text resumeStyle ]
+                ]
 
 
 resumeStyle : String
-resumeStyle = """
+resumeStyle =
+    """
 
 .elm-debugger-resume {
   width: 100%;

--- a/src/Debugger/Main.elm
+++ b/src/Debugger/Main.elm
@@ -145,7 +145,6 @@ type Msg msg
     | Resize Int Int
     | UserMsg msg
     | ExpandoMsg ExpandoTarget Expando.Msg
-    | HistoryMsg History.Msg
     | Resume
     | Jump Int
     | Open
@@ -246,26 +245,6 @@ wrapUpdate update msg model =
 
                 ModelExpando ->
                     ( { model | modelExpando = Expando.update eMsg model.modelExpando }
-                    , Cmd.none
-                    )
-
-        HistoryMsg historyMsg ->
-            case historyMsg of
-                History.SelectMsg idx ->
-                    wrapUpdate update (Jump idx) model
-
-                History.ToggleMulti id ->
-                    let
-                        currentHistory =
-                            model.history
-                    in
-                    ( { model
-                        | history =
-                            { currentHistory
-                                | messageHierarchy =
-                                    History.openMultiContainer id currentHistory.messageHierarchy
-                            }
-                      }
                     , Cmd.none
                     )
 
@@ -618,7 +597,7 @@ viewSidebar state history layout offsetStyle =
                 ]
                 [ draggableBorderHorizontal
                 , slider history maybeIndex
-                , Html.map HistoryMsg (History.view maybeIndex history)
+                , Html.map Jump (History.view maybeIndex history)
                 , playButton maybeIndex
                 ]
 
@@ -634,7 +613,7 @@ viewSidebar state history layout offsetStyle =
                 ]
                 [ draggableBorder
                 , slider history maybeIndex
-                , Html.map HistoryMsg (History.view maybeIndex history)
+                , Html.map Jump (History.view maybeIndex history)
                 , playButton maybeIndex
                 ]
 

--- a/src/Debugger/Main.elm
+++ b/src/Debugger/Main.elm
@@ -283,6 +283,7 @@ download metadata history =
         [ ("metadata", Metadata.encode metadata)
         , ("history", History.encode history)
         ]
+        |> Elm.Kernel.Json.unwrap
   in
     Task.perform (\_ -> NoOp) (Elm.Kernel.Debugger.download historyLength json)
 

--- a/src/Debugger/Main.elm
+++ b/src/Debugger/Main.elm
@@ -291,7 +291,7 @@ wrapUpdate update msg model =
 
         SliderJump index ->
             let
-                ( modelAfterJump, jumpCmds ) =
+                ( modelAfterJump, _ ) =
                     wrapUpdate update (Jump index) model
             in
             ( modelAfterJump
@@ -304,20 +304,20 @@ wrapUpdate update msg model =
             )
 
         Up ->
-            let
-                ( index, history ) =
-                    case model.state of
-                        Paused i _ _ _ cachedHistory ->
-                            ( i + 1, cachedHistory )
+            case model.state of
+                Paused i _ _ _ cachedHistory ->
+                    let
+                        targetIndex =
+                            i + 1
+                    in
+                    if targetIndex < History.size cachedHistory then
+                        wrapUpdate update (SliderJump targetIndex) model
 
-                        Running _ ->
-                            ( 0, model.history )
-            in
-            if index < History.size history then
-                wrapUpdate update (Jump index) model
+                    else
+                        wrapUpdate update Resume model
 
-            else
-                wrapUpdate update Resume model
+                Running _ ->
+                    ( model, Cmd.none )
 
         Down ->
             case model.state of
@@ -326,7 +326,7 @@ wrapUpdate update msg model =
 
                 Paused index _ userModel userMsg _ ->
                     if index > 0 then
-                        wrapUpdate update (Jump (index - 1)) model
+                        wrapUpdate update (SliderJump (index - 1)) model
 
                     else
                         ( model, Cmd.none )

--- a/src/Debugger/Main.elm
+++ b/src/Debugger/Main.elm
@@ -220,7 +220,7 @@ wrapUpdate update msg model =
                     ( { model
                         | history = newHistory
                         , state = Running newUserModel
-                        , modelExpando = Expando.init newUserModel
+                        , modelExpando = Expando.merge newUserModel model.modelExpando
                         , messageExpando = Just (Expando.init userMsg)
                       }
                     , Cmd.batch

--- a/src/Debugger/Main.elm
+++ b/src/Debugger/Main.elm
@@ -15,7 +15,7 @@ import Debugger.Report as Report
 import Elm.Kernel.Debugger
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import Html.Events exposing (onClick)
+import Html.Events exposing (onClick, onInput)
 import Json.Decode as Decode
 import Json.Encode as Encode
 import Task exposing (Task)
@@ -425,8 +425,38 @@ viewSidebar state history =
         , style "color" "white"
         , style "background-color" "rgb(61, 61, 61)"
         ]
-        [ Html.map Jump (History.view maybeIndex history)
+        [ slider history maybeIndex
+        , Html.map Jump (History.view maybeIndex history)
         , playButton maybeIndex
+        ]
+
+
+slider : History model msg -> Maybe Int -> Html (Msg msg)
+slider history maybeIndex =
+    let
+        lastIndex =
+            History.size history - 1
+
+        selectedIndex =
+            Maybe.withDefault lastIndex maybeIndex
+    in
+    div
+        [ style "width" "100%"
+        , style "text-align" "center"
+        , style "background-color" "rgb(50, 50, 50)"
+        , style "padding" "0 20px"
+        , style "box-sizing" "border-box"
+        ]
+        [ input
+            [ type_ "range"
+            , style "width" "100%"
+            , style "height" "24px"
+            , Html.Attributes.min "0"
+            , Html.Attributes.max (String.fromInt lastIndex)
+            , value (String.fromInt selectedIndex)
+            , onInput (String.toInt >> Maybe.withDefault lastIndex >> Jump)
+            ]
+            []
         ]
 
 

--- a/src/Debugger/Main.elm
+++ b/src/Debugger/Main.elm
@@ -234,7 +234,7 @@ wrapUpdate update msg model =
 
     Import ->
       withGoodMetadata model <| \_ ->
-        ( model, upload )
+        ( model, upload model.popout )
 
     Export ->
       withGoodMetadata model <| \metadata ->
@@ -267,9 +267,9 @@ scroll popout =
   Task.perform (always NoOp) (Elm.Kernel.Debugger.scroll popout)
 
 
-upload : Cmd (Msg msg)
-upload =
-  Task.perform Upload (Elm.Kernel.Debugger.upload ())
+upload : Popout -> Cmd (Msg msg)
+upload popout =
+  Task.perform Upload (Elm.Kernel.Debugger.upload popout)
 
 
 download : Metadata -> History model msg -> Cmd (Msg msg)

--- a/src/Debugger/Main.elm
+++ b/src/Debugger/Main.elm
@@ -122,7 +122,7 @@ wrapInit metadata popout init flags =
       , overlay = Overlay.none
       , popout = popout
       , sidePanelResizable = False
-      , sidePanelWidth = 500
+      , sidePanelWidth = 300
       }
     , Cmd.map UserMsg userCommands
     )
@@ -142,9 +142,8 @@ type Msg msg
     | Open
     | Up
     | Down
-    | InitiatePanelSizing
-    | StopPanelSizing
-    | SizePanel Int
+    | EnableSidePanelResizing Bool
+    | ResizeSidePanel Int
     | Import
     | Export
     | Upload String
@@ -300,17 +299,12 @@ wrapUpdate update msg model =
                     else
                         wrapUpdate update (Jump (index + 1)) model
 
-        InitiatePanelSizing ->
-            ( { model | sidePanelResizable = True }
+        EnableSidePanelResizing enabled ->
+            ( { model | sidePanelResizable = enabled }
             , Cmd.none
             )
 
-        StopPanelSizing ->
-            ( { model | sidePanelResizable = False }
-            , Cmd.none
-            )
-
-        SizePanel currentX ->
+        ResizeSidePanel currentX ->
             ( { model | sidePanelWidth = Basics.max 150 currentX }
             , Cmd.none
             )
@@ -473,8 +467,8 @@ popoutView { history, state, expandTarget, expando, sidePanelWidth, sidePanelRes
     node "body"
         (if sidePanelResizable then
             List.append bodyAttributes
-                [ onMouseMove SizePanel
-                , onMouseUp StopPanelSizing
+                [ onMouseMove ResizeSidePanel
+                , onMouseUp (EnableSidePanelResizing False)
 
                 -- Disable highlighting when dragging
                 , style "-webkit-user-select" "none"
@@ -539,7 +533,7 @@ draggableBorder =
         , style "width" "5px"
         , style "background-color" "black"
         , style "cursor" "col-resize"
-        , onMouseDown InitiatePanelSizing
+        , onMouseDown (EnableSidePanelResizing True)
         ]
         []
 
@@ -654,7 +648,7 @@ expandConfigPanel target =
         , style "box-sizing" "border-box"
         , style "padding" "2px 10px"
         ]
-        [ span [] [ text "Expand: " ]
+        [ text "Expand: "
         , selectableTextButton (target == ExpandMsg) (SetExpandTarget ExpandMsg) "Message"
         , text " / "
         , selectableTextButton (target == ExpandModel) (SetExpandTarget ExpandModel) "Model"

--- a/src/Debugger/Main.elm
+++ b/src/Debugger/Main.elm
@@ -137,6 +137,7 @@ type Msg msg
     | UserMsg msg
     | SetExpandTarget ExpandTarget
     | ExpandoMsg Expando.Msg
+    | HistoryMsg History.Msg
     | Resume
     | Jump Int
     | Open
@@ -225,6 +226,26 @@ wrapUpdate update msg model =
             ( { model | expando = Expando.update eMsg model.expando }
             , Cmd.none
             )
+
+        HistoryMsg historyMsg ->
+            case historyMsg of
+                History.SelectMsg idx ->
+                    wrapUpdate update (Jump idx) model
+
+                History.ToggleMulti id ->
+                    let
+                        currentHistory =
+                            model.history
+                    in
+                    ( { model
+                        | history =
+                            { currentHistory
+                                | messageHierarchy =
+                                    History.openMultiContainer id currentHistory.messageHierarchy
+                            }
+                      }
+                    , Cmd.none
+                    )
 
         Resume ->
             case model.state of
@@ -518,7 +539,7 @@ viewSidebar state history sidePanelWidthStyle =
         ]
         [ draggableBorder
         , slider history maybeIndex
-        , Html.map Jump (History.view maybeIndex history)
+        , Html.map HistoryMsg (History.view maybeIndex history)
         , playButton maybeIndex
         ]
 

--- a/src/Debugger/Main.elm
+++ b/src/Debugger/Main.elm
@@ -294,7 +294,7 @@ wrapUpdate update msg model =
         Jump index ->
             let
                 ( currentModel, currentMsg ) =
-                    History.getRecent model.history
+                    History.getRecent update model.history
 
                 ( indexModel, indexMsg ) =
                     History.get update index model.history

--- a/src/Debugger/Metadata.elm
+++ b/src/Debugger/Metadata.elm
@@ -1,16 +1,19 @@
 module Debugger.Metadata exposing
-  ( Metadata
-  , check
-  , decode, decoder, encode
-  , Error, ProblemType, Problem(..)
-  )
-
+    ( Error
+    , Metadata
+    , Problem(..)
+    , ProblemType
+    , check
+    , decode
+    , decoder
+    , encode
+    )
 
 import Array exposing (Array)
+import Debugger.Report as Report exposing (Report)
 import Dict exposing (Dict)
 import Json.Decode as Decode
 import Json.Encode as Encode
-import Debugger.Report as Report exposing (Report)
 
 
 
@@ -18,9 +21,9 @@ import Debugger.Report as Report exposing (Report)
 
 
 type alias Metadata =
-  { versions : Versions
-  , types : Types
-  }
+    { versions : Versions
+    , types : Types
+    }
 
 
 
@@ -28,8 +31,8 @@ type alias Metadata =
 
 
 type alias Versions =
-  { elm : String
-  }
+    { elm : String
+    }
 
 
 
@@ -37,22 +40,22 @@ type alias Versions =
 
 
 type alias Types =
-  { message : String
-  , aliases : Dict String Alias
-  , unions : Dict String Union
-  }
+    { message : String
+    , aliases : Dict String Alias
+    , unions : Dict String Union
+    }
 
 
 type alias Alias =
-  { args : List String
-  , tipe : String
-  }
+    { args : List String
+    , tipe : String
+    }
 
 
 type alias Union =
-  { args : List String
-  , tags : Dict String (List String)
-  }
+    { args : List String
+    , tags : Dict String (List String)
+    }
 
 
 
@@ -60,84 +63,88 @@ type alias Union =
 
 
 isPortable : Metadata -> Maybe Error
-isPortable {types} =
-  let
-    badAliases =
-      Dict.foldl collectBadAliases [] types.aliases
-  in
+isPortable { types } =
+    let
+        badAliases =
+            Dict.foldl collectBadAliases [] types.aliases
+    in
     case Dict.foldl collectBadUnions badAliases types.unions of
-      [] ->
-        Nothing
+        [] ->
+            Nothing
 
-      problems ->
-        Just (Error types.message problems)
+        problems ->
+            Just (Error types.message problems)
 
 
 type alias Error =
-  { message : String
-  , problems : List ProblemType
-  }
+    { message : String
+    , problems : List ProblemType
+    }
 
 
 type alias ProblemType =
-  { name : String
-  , problems : List Problem
-  }
+    { name : String
+    , problems : List Problem
+    }
 
 
 type Problem
-  = Function
-  | Decoder
-  | Task
-  | Process
-  | Socket
-  | Request
-  | Program
-  | VirtualDom
+    = Function
+    | Decoder
+    | Task
+    | Process
+    | Socket
+    | Request
+    | Program
+    | VirtualDom
 
 
 collectBadAliases : String -> Alias -> List ProblemType -> List ProblemType
-collectBadAliases name {tipe} list =
-  case findProblems tipe of
-    [] ->
-      list
+collectBadAliases name { tipe } list =
+    case findProblems tipe of
+        [] ->
+            list
 
-    problems ->
-      ProblemType name problems :: list
+        problems ->
+            ProblemType name problems :: list
 
 
 collectBadUnions : String -> Union -> List ProblemType -> List ProblemType
-collectBadUnions name {tags} list =
-  case List.concatMap findProblems (List.concat (Dict.values tags)) of
-    [] ->
-      list
+collectBadUnions name { tags } list =
+    case List.concatMap findProblems (List.concat (Dict.values tags)) of
+        [] ->
+            list
 
-    problems ->
-      ProblemType name problems :: list
+        problems ->
+            ProblemType name problems :: list
 
 
 findProblems : String -> List Problem
 findProblems tipe =
-  List.filterMap (hasProblem tipe) problemTable
+    List.filterMap (hasProblem tipe) problemTable
 
 
-hasProblem : String -> (Problem, String) -> Maybe Problem
-hasProblem tipe (problem, token) =
-  if String.contains token tipe then Just problem else Nothing
+hasProblem : String -> ( Problem, String ) -> Maybe Problem
+hasProblem tipe ( problem, token ) =
+    if String.contains token tipe then
+        Just problem
+
+    else
+        Nothing
 
 
-problemTable : List (Problem, String)
+problemTable : List ( Problem, String )
 problemTable =
-  [ ( Function, "->" )
-  , ( Decoder, "Json.Decode.Decoder" )
-  , ( Task, "Task.Task" )
-  , ( Process, "Process.Id" )
-  , ( Socket, "WebSocket.LowLevel.WebSocket" )
-  , ( Request, "Http.Request" )
-  , ( Program, "Platform.Program" )
-  , ( VirtualDom, "VirtualDom.Node" )
-  , ( VirtualDom, "VirtualDom.Attribute" )
-  ]
+    [ ( Function, "->" )
+    , ( Decoder, "Json.Decode.Decoder" )
+    , ( Task, "Task.Task" )
+    , ( Process, "Process.Id" )
+    , ( Socket, "WebSocket.LowLevel.WebSocket" )
+    , ( Request, "Http.Request" )
+    , ( Program, "Platform.Program" )
+    , ( VirtualDom, "VirtualDom.Node" )
+    , ( VirtualDom, "VirtualDom.Attribute" )
+    ]
 
 
 
@@ -146,28 +153,28 @@ problemTable =
 
 check : Metadata -> Metadata -> Report
 check old new =
-  if old.versions.elm /= new.versions.elm then
-    Report.VersionChanged old.versions.elm new.versions.elm
+    if old.versions.elm /= new.versions.elm then
+        Report.VersionChanged old.versions.elm new.versions.elm
 
-  else
-    checkTypes old.types new.types
+    else
+        checkTypes old.types new.types
 
 
 checkTypes : Types -> Types -> Report
 checkTypes old new =
-  if old.message /= new.message then
-    Report.MessageChanged old.message new.message
+    if old.message /= new.message then
+        Report.MessageChanged old.message new.message
 
-  else
-    []
-      |> Dict.merge ignore checkAlias ignore old.aliases new.aliases
-      |> Dict.merge ignore checkUnion ignore old.unions new.unions
-      |> Report.SomethingChanged
+    else
+        []
+            |> Dict.merge ignore checkAlias ignore old.aliases new.aliases
+            |> Dict.merge ignore checkUnion ignore old.unions new.unions
+            |> Report.SomethingChanged
 
 
 ignore : String -> value -> a -> a
 ignore key value report =
-  report
+    report
 
 
 
@@ -176,11 +183,11 @@ ignore key value report =
 
 checkAlias : String -> Alias -> Alias -> List Report.Change -> List Report.Change
 checkAlias name old new changes =
-  if old.tipe == new.tipe && old.args == new.args then
-    changes
+    if old.tipe == new.tipe && old.args == new.args then
+        changes
 
-  else
-    Report.AliasChange name :: changes
+    else
+        Report.AliasChange name :: changes
 
 
 
@@ -189,35 +196,35 @@ checkAlias name old new changes =
 
 checkUnion : String -> Union -> Union -> List Report.Change -> List Report.Change
 checkUnion name old new changes =
-  let
-    tagChanges =
-      Dict.merge removeTag checkTag addTag old.tags new.tags <|
-        Report.emptyTagChanges (old.args == new.args)
-  in
+    let
+        tagChanges =
+            Dict.merge removeTag checkTag addTag old.tags new.tags <|
+                Report.emptyTagChanges (old.args == new.args)
+    in
     if Report.hasTagChanges tagChanges then
-      changes
+        changes
 
     else
-      Report.UnionChange name tagChanges :: changes
+        Report.UnionChange name tagChanges :: changes
 
 
 removeTag : String -> a -> Report.TagChanges -> Report.TagChanges
 removeTag tag _ changes =
-  { changes | removed = tag :: changes.removed }
+    { changes | removed = tag :: changes.removed }
 
 
 addTag : String -> a -> Report.TagChanges -> Report.TagChanges
 addTag tag _ changes =
-  { changes | added = tag :: changes.added }
+    { changes | added = tag :: changes.added }
 
 
 checkTag : String -> a -> a -> Report.TagChanges -> Report.TagChanges
 checkTag tag old new changes =
-  if old == new then
-    changes
+    if old == new then
+        changes
 
-  else
-    { changes | changed = tag :: changes.changed }
+    else
+        { changes | changed = tag :: changes.changed }
 
 
 
@@ -226,52 +233,52 @@ checkTag tag old new changes =
 
 decode : Encode.Value -> Result Error Metadata
 decode value =
-  case Decode.decodeValue decoder value of
-    Err _ ->
-      Err (Error "The compiler is generating bad metadata. This is a compiler bug!" [])
+    case Decode.decodeValue decoder value of
+        Err _ ->
+            Err (Error "The compiler is generating bad metadata. This is a compiler bug!" [])
 
-    Ok metadata ->
-      case isPortable metadata of
-        Nothing ->
-          Ok metadata
+        Ok metadata ->
+            case isPortable metadata of
+                Nothing ->
+                    Ok metadata
 
-        Just error ->
-          Err error
+                Just error ->
+                    Err error
 
 
 decoder : Decode.Decoder Metadata
 decoder =
-  Decode.map2 Metadata
-    (Decode.field "versions" decodeVersions)
-    (Decode.field "types" decodeTypes)
+    Decode.map2 Metadata
+        (Decode.field "versions" decodeVersions)
+        (Decode.field "types" decodeTypes)
 
 
 decodeVersions : Decode.Decoder Versions
 decodeVersions =
-  Decode.map Versions
-    (Decode.field "elm" Decode.string)
+    Decode.map Versions
+        (Decode.field "elm" Decode.string)
 
 
 decodeTypes : Decode.Decoder Types
 decodeTypes =
-  Decode.map3 Types
-    (Decode.field "message" Decode.string)
-    (Decode.field "aliases" (Decode.dict decodeAlias))
-    (Decode.field "unions" (Decode.dict decodeUnion))
+    Decode.map3 Types
+        (Decode.field "message" Decode.string)
+        (Decode.field "aliases" (Decode.dict decodeAlias))
+        (Decode.field "unions" (Decode.dict decodeUnion))
 
 
 decodeUnion : Decode.Decoder Union
 decodeUnion =
-  Decode.map2 Union
-    (Decode.field "args" (Decode.list Decode.string))
-    (Decode.field "tags" (Decode.dict (Decode.list Decode.string)))
+    Decode.map2 Union
+        (Decode.field "args" (Decode.list Decode.string))
+        (Decode.field "tags" (Decode.dict (Decode.list Decode.string)))
 
 
 decodeAlias : Decode.Decoder Alias
 decodeAlias =
-  Decode.map2 Alias
-    (Decode.field "args" (Decode.list Decode.string))
-    (Decode.field "type" (Decode.string))
+    Decode.map2 Alias
+        (Decode.field "args" (Decode.list Decode.string))
+        (Decode.field "type" Decode.string)
 
 
 
@@ -280,47 +287,45 @@ decodeAlias =
 
 encode : Metadata -> Encode.Value
 encode { versions, types } =
-  Encode.object
-    [ ("versions", encodeVersions versions)
-    , ("types", encodeTypes types)
-    ]
+    Encode.object
+        [ ( "versions", encodeVersions versions )
+        , ( "types", encodeTypes types )
+        ]
 
 
 encodeVersions : Versions -> Encode.Value
 encodeVersions { elm } =
-  Encode.object [("elm", Encode.string elm)]
+    Encode.object [ ( "elm", Encode.string elm ) ]
 
 
 encodeTypes : Types -> Encode.Value
 encodeTypes { message, unions, aliases } =
-  Encode.object
-    [ ("message", Encode.string message)
-    , ("aliases", encodeDict encodeAlias aliases)
-    , ("unions", encodeDict encodeUnion unions)
-    ]
+    Encode.object
+        [ ( "message", Encode.string message )
+        , ( "aliases", encodeDict encodeAlias aliases )
+        , ( "unions", encodeDict encodeUnion unions )
+        ]
 
 
 encodeAlias : Alias -> Encode.Value
 encodeAlias { args, tipe } =
-  Encode.object
-    [ ("args", Encode.list Encode.string args)
-    , ("type", Encode.string tipe)
-    ]
+    Encode.object
+        [ ( "args", Encode.list Encode.string args )
+        , ( "type", Encode.string tipe )
+        ]
 
 
 encodeUnion : Union -> Encode.Value
 encodeUnion { args, tags } =
-  Encode.object
-    [ ("args", Encode.list Encode.string args)
-    , ("tags", encodeDict (Encode.list Encode.string) tags)
-    ]
+    Encode.object
+        [ ( "args", Encode.list Encode.string args )
+        , ( "tags", encodeDict (Encode.list Encode.string) tags )
+        ]
 
 
 encodeDict : (a -> Encode.Value) -> Dict String a -> Encode.Value
 encodeDict f dict =
-  dict
-    |> Dict.map (\key value -> f value)
-    |> Dict.toList
-    |> Encode.object
-
-
+    dict
+        |> Dict.map (\key value -> f value)
+        |> Dict.toList
+        |> Encode.object

--- a/src/Debugger/Overlay.elm
+++ b/src/Debugger/Overlay.elm
@@ -1,115 +1,136 @@
 module Debugger.Overlay exposing
-  ( State, none, corruptImport, badMetadata
-  , Msg, close, assessImport
-  , BlockerType(..), toBlockerType
-  , Config
-  , view
-  , viewImportExport
-  )
+    ( BlockerType(..)
+    , Config
+    , Msg
+    , State
+    , assessImport
+    , badMetadata
+    , close
+    , corruptImport
+    , none
+    , toBlockerType
+    , view
+    , viewImportExport
+    )
 
-import Json.Decode as Decode
-import Json.Encode as Encode
+import Debugger.Metadata as Metadata exposing (Metadata)
+import Debugger.Report as Report exposing (Report)
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (onClick)
-import Debugger.Metadata as Metadata exposing (Metadata)
-import Debugger.Report as Report exposing (Report)
-
+import Json.Decode as Decode
+import Json.Encode as Encode
 
 
 type State
-  = None
-  | BadMetadata Metadata.Error
-  | BadImport Report
-  | RiskyImport Report Encode.Value
+    = None
+    | BadMetadata Metadata.Error
+    | BadImport Report
+    | RiskyImport Report Encode.Value
 
 
 none : State
 none =
-  None
+    None
 
 
 corruptImport : State
 corruptImport =
-  BadImport Report.CorruptHistory
+    BadImport Report.CorruptHistory
 
 
 badMetadata : Metadata.Error -> State
 badMetadata =
-  BadMetadata
+    BadMetadata
 
 
 
 --  UPDATE
 
 
-type Msg = Cancel | Proceed
+type Msg
+    = Cancel
+    | Proceed
 
 
 close : Msg -> State -> Maybe Encode.Value
 close msg state =
-  case state of
-    None ->
-      Nothing
+    case state of
+        None ->
+            Nothing
 
-    BadMetadata _ ->
-      Nothing
+        BadMetadata _ ->
+            Nothing
 
-    BadImport _ ->
-      Nothing
+        BadImport _ ->
+            Nothing
 
-    RiskyImport _ rawHistory ->
-      case msg of
-        Cancel ->
-          Nothing
+        RiskyImport _ rawHistory ->
+            case msg of
+                Cancel ->
+                    Nothing
 
-        Proceed ->
-          Just rawHistory
+                Proceed ->
+                    Just rawHistory
 
 
 assessImport : Metadata -> String -> Result State Encode.Value
 assessImport metadata jsonString =
-  case Decode.decodeString uploadDecoder jsonString of
-    Err _ ->
-      Err corruptImport
+    case Decode.decodeString uploadDecoder jsonString of
+        Err _ ->
+            Err corruptImport
 
-    Ok (foreignMetadata, rawHistory) ->
-      let
-        report =
-          Metadata.check foreignMetadata metadata
-      in
-        case Report.evaluate report of
-          Report.Impossible ->
-            Err (BadImport report)
+        Ok ( foreignMetadata, rawHistory ) ->
+            let
+                report =
+                    Metadata.check foreignMetadata metadata
+            in
+            case Report.evaluate report of
+                Report.Impossible ->
+                    Err (BadImport report)
 
-          Report.Risky ->
-            Err (RiskyImport report rawHistory)
+                Report.Risky ->
+                    Err (RiskyImport report rawHistory)
 
-          Report.Fine ->
-            Ok rawHistory
+                Report.Fine ->
+                    Ok rawHistory
 
 
-uploadDecoder : Decode.Decoder (Metadata, Encode.Value)
+uploadDecoder : Decode.Decoder ( Metadata, Encode.Value )
 uploadDecoder =
-  Decode.map2 (\x y -> (x,y))
-    (Decode.field "metadata" Metadata.decoder)
-    (Decode.field "history" Decode.value)
+    Decode.map2 (\x y -> ( x, y ))
+        (Decode.field "metadata" Metadata.decoder)
+        (Decode.field "history" Decode.value)
 
 
 
 -- BLOCKERS
 
 
-type BlockerType = BlockNone | BlockMost | BlockAll
+type BlockerType
+    = BlockNone
+    | BlockMost
+    | BlockAll
 
 
 toBlockerType : Bool -> State -> BlockerType
 toBlockerType isPaused state =
-  case state of
-    None            -> if isPaused then BlockAll else BlockNone
-    BadMetadata _   -> BlockMost
-    BadImport _     -> BlockMost
-    RiskyImport _ _ -> BlockMost
+    case state of
+        None ->
+            if isPaused then
+                BlockAll
+
+            else
+                BlockNone
+
+        BadMetadata _ ->
+            BlockMost
+
+        BadImport _ ->
+            BlockMost
+
+        RiskyImport _ _ ->
+            BlockMost
 
 
 
@@ -117,67 +138,67 @@ toBlockerType isPaused state =
 
 
 type alias Config msg =
-  { resume : msg
-  , open : msg
-  , importHistory : msg
-  , exportHistory : msg
-  , wrap : Msg -> msg
-  }
+    { resume : msg
+    , open : msg
+    , importHistory : msg
+    , exportHistory : msg
+    , wrap : Msg -> msg
+    }
 
 
 view : Config msg -> Bool -> Bool -> Int -> State -> Html msg
 view config isPaused isOpen numMsgs state =
-  case state of
-    None ->
-      if isOpen then
-        text ""
+    case state of
+        None ->
+            if isOpen then
+                text ""
 
-      else
-        if isPaused then
-          div
-            [ style "width" "100%"
-            , style "height" "100%"
-            , style "cursor" "pointer"
-            , style "text-align" "center"
-            , style "pointer-events" "auto"
-            , style "background-color" "rgba(200, 200, 200, 0.7)"
-            , style "color" "white"
-            , style "font-family" "'Trebuchet MS', 'Lucida Grande', 'Bitstream Vera Sans', 'Helvetica Neue', sans-serif"
-            , style "z-index" "2147483646"
-            , onClick config.resume
-            ]
-            [ div
-                [ style "position" "absolute"
-                , style "top" "calc(50% - 40px)"
-                , style "font-size" "80px"
-                , style "line-height" "80px"
-                , style "height" "80px"
-                , style "width" "100%"
-                ]
-                [ text "Click to Resume"
-                ]
-            , viewMiniControls config numMsgs
-            ]
-        else
-          viewMiniControls config numMsgs
+            else if isPaused then
+                div
+                    [ style "width" "100%"
+                    , style "height" "100%"
+                    , style "cursor" "pointer"
+                    , style "text-align" "center"
+                    , style "pointer-events" "auto"
+                    , style "background-color" "rgba(200, 200, 200, 0.7)"
+                    , style "color" "white"
+                    , style "font-family" "'Trebuchet MS', 'Lucida Grande', 'Bitstream Vera Sans', 'Helvetica Neue', sans-serif"
+                    , style "z-index" "2147483646"
+                    , onClick config.resume
+                    ]
+                    [ div
+                        [ style "position" "absolute"
+                        , style "top" "calc(50% - 40px)"
+                        , style "font-size" "80px"
+                        , style "line-height" "80px"
+                        , style "height" "80px"
+                        , style "width" "100%"
+                        ]
+                        [ text "Click to Resume"
+                        ]
+                    , viewMiniControls config numMsgs
+                    ]
 
-    BadMetadata badMetadata_ ->
-      viewMessage config
-        "Cannot use Import or Export"
-        (viewBadMetadata badMetadata_)
-        (Accept "Ok")
+            else
+                viewMiniControls config numMsgs
 
-    BadImport report ->
-      viewMessage config
-        "Cannot Import History"
-        (viewReport True report)
-        (Accept "Ok")
+        BadMetadata badMetadata_ ->
+            viewMessage config
+                "Cannot use Import or Export"
+                (viewBadMetadata badMetadata_)
+                (Accept "Ok")
 
-    RiskyImport report _ ->
-      viewMessage config
-        "Warning"
-        (viewReport False report)
-        (Choose "Cancel" "Import Anyway")
+        BadImport report ->
+            viewMessage config
+                "Cannot Import History"
+                (viewReport True report)
+                (Accept "Ok")
+
+        RiskyImport report _ ->
+            viewMessage config
+                "Warning"
+                (viewReport False report)
+                (Choose "Cancel" "Import Anyway")
 
 
 
@@ -186,91 +207,104 @@ view config isPaused isOpen numMsgs state =
 
 viewMessage : Config msg -> String -> List (Html msg) -> Buttons -> Html msg
 viewMessage config title details buttons =
-  div
-    [ id "elm-debugger-overlay"
-    , style "position" "fixed"
-    , style "top" "0"
-    , style "left" "0"
-    , style "width" "100%"
-    , style "height" "100%"
-    , style "color" "white"
-    , style "pointer-events" "none"
-    , style "font-family" "'Trebuchet MS', 'Lucida Grande', 'Bitstream Vera Sans', 'Helvetica Neue', sans-serif"
-    , style "z-index" "2147483647"
-    ]
-    [ div
-        [ style "position" "absolute"
-        , style "width" "600px"
+    div
+        [ id "elm-debugger-overlay"
+        , style "position" "fixed"
+        , style "top" "0"
+        , style "left" "0"
+        , style "width" "100%"
         , style "height" "100%"
-        , style "padding-left" "calc(50% - 300px)"
-        , style "padding-right" "calc(50% - 300px)"
-        , style "background-color" "rgba(200, 200, 200, 0.7)"
-        , style "pointer-events" "auto"
+        , style "color" "white"
+        , style "pointer-events" "none"
+        , style "font-family" "'Trebuchet MS', 'Lucida Grande', 'Bitstream Vera Sans', 'Helvetica Neue', sans-serif"
+        , style "z-index" "2147483647"
         ]
         [ div
-            [ style "font-size" "36px"
-            , style "height" "80px"
-            , style "background-color" "rgb(50, 50, 50)"
-            , style "padding-left" "22px"
-            , style "vertical-align" "middle"
-            , style "line-height" "80px"
+            [ style "position" "absolute"
+            , style "width" "600px"
+            , style "height" "100%"
+            , style "padding-left" "calc(50% - 300px)"
+            , style "padding-right" "calc(50% - 300px)"
+            , style "background-color" "rgba(200, 200, 200, 0.7)"
+            , style "pointer-events" "auto"
             ]
-            [ text title ]
-        , div
-            [ id "elm-debugger-details"
-            , style "padding" " 8px 20px"
-            , style "overflow-y" "auto"
-            , style "max-height" "calc(100% - 156px)"
-            , style "background-color" "rgb(61, 61, 61)"
+            [ div
+                [ style "font-size" "36px"
+                , style "height" "80px"
+                , style "background-color" "rgb(50, 50, 50)"
+                , style "padding-left" "22px"
+                , style "vertical-align" "middle"
+                , style "line-height" "80px"
+                ]
+                [ text title ]
+            , div
+                [ id "elm-debugger-details"
+                , style "padding" " 8px 20px"
+                , style "overflow-y" "auto"
+                , style "max-height" "calc(100% - 156px)"
+                , style "background-color" "rgb(61, 61, 61)"
+                ]
+                details
+            , Html.map config.wrap (viewButtons buttons)
             ]
-            details
-        , Html.map config.wrap (viewButtons buttons)
         ]
-    ]
 
 
 viewReport : Bool -> Report -> List (Html msg)
 viewReport isBad report =
-  case report of
-    Report.CorruptHistory ->
-      [ text "Looks like this history file is corrupt. I cannot understand it."
-      ]
+    case report of
+        Report.CorruptHistory ->
+            [ text "Looks like this history file is corrupt. I cannot understand it."
+            ]
 
-    Report.VersionChanged old new ->
-      [ text <|
-          "This history was created with Elm "
-          ++ old ++ ", but you are using Elm "
-          ++ new ++ " right now."
-      ]
+        Report.VersionChanged old new ->
+            [ text <|
+                "This history was created with Elm "
+                    ++ old
+                    ++ ", but you are using Elm "
+                    ++ new
+                    ++ " right now."
+            ]
 
-    Report.MessageChanged old new ->
-      [ text <|
-          "To import some other history, the overall message type must"
-          ++ " be the same. The old history has "
-      , viewCode old
-      , text " messages, but the new program works with "
-      , viewCode new
-      , text " messages."
-      ]
+        Report.MessageChanged old new ->
+            [ text <|
+                "To import some other history, the overall message type must"
+                    ++ " be the same. The old history has "
+            , viewCode old
+            , text " messages, but the new program works with "
+            , viewCode new
+            , text " messages."
+            ]
 
-    Report.SomethingChanged changes ->
-      [ p [] [ text (if isBad then explanationBad else explanationRisky) ]
-      , ul
-          [ style "list-style-type" "none"
-          , style "padding-left" "20px"
-          ]
-          (List.map viewChange changes)
-      ]
+        Report.SomethingChanged changes ->
+            [ p []
+                [ text
+                    (if isBad then
+                        explanationBad
+
+                     else
+                        explanationRisky
+                    )
+                ]
+            , ul
+                [ style "list-style-type" "none"
+                , style "padding-left" "20px"
+                ]
+                (List.map viewChange changes)
+            ]
 
 
 explanationBad : String
-explanationBad = """
+explanationBad =
+    """
 The messages in this history do not match the messages handled by your
 program. I noticed changes in the following types:
 """
 
+
 explanationRisky : String
-explanationRisky = """
+explanationRisky =
+    """
 This history seems old. It will work with this program, but some
 messages have been added since the history was created:
 """
@@ -278,81 +312,84 @@ messages have been added since the history was created:
 
 viewCode : String -> Html msg
 viewCode name =
-  code [] [ text name ]
+    code [] [ text name ]
 
 
 viewChange : Report.Change -> Html msg
 viewChange change =
-  li [ style "margin" "8px 0" ] <|
-    case change of
-      Report.AliasChange name ->
-        [ span [ style "font-size" "1.5em" ] [ viewCode name ]
-        ]
+    li [ style "margin" "8px 0" ] <|
+        case change of
+            Report.AliasChange name ->
+                [ span [ style "font-size" "1.5em" ] [ viewCode name ]
+                ]
 
-      Report.UnionChange name { removed, changed, added, argsMatch } ->
-        [ span [ style "font-size" "1.5em" ] [ viewCode name ]
-        , ul
-            [ style "list-style-type" "disc"
-            , style "padding-left" "2em"
-            ]
-            [ viewMention removed "Removed "
-            , viewMention changed "Changed "
-            , viewMention added "Added "
-            ]
-        , if argsMatch then
-            text ""
-          else
-            text "This may be due to the fact that the type variable names changed."
-        ]
+            Report.UnionChange name { removed, changed, added, argsMatch } ->
+                [ span [ style "font-size" "1.5em" ] [ viewCode name ]
+                , ul
+                    [ style "list-style-type" "disc"
+                    , style "padding-left" "2em"
+                    ]
+                    [ viewMention removed "Removed "
+                    , viewMention changed "Changed "
+                    , viewMention added "Added "
+                    ]
+                , if argsMatch then
+                    text ""
+
+                  else
+                    text "This may be due to the fact that the type variable names changed."
+                ]
 
 
 viewMention : List String -> String -> Html msg
 viewMention tags verbed =
-  case List.map viewCode (List.reverse tags) of
-    [] ->
-      text ""
+    case List.map viewCode (List.reverse tags) of
+        [] ->
+            text ""
 
-    [tag] ->
-      li []
-        [ text verbed, tag, text "." ]
+        [ tag ] ->
+            li []
+                [ text verbed, tag, text "." ]
 
-    [tag2, tag1] ->
-      li []
-        [ text verbed, tag1, text " and ", tag2, text "." ]
+        [ tag2, tag1 ] ->
+            li []
+                [ text verbed, tag1, text " and ", tag2, text "." ]
 
-    lastTag :: otherTags ->
-      li [] <|
-        text verbed
-        :: List.intersperse (text ", ") (List.reverse otherTags)
-        ++ [ text ", and ", lastTag, text "." ]
+        lastTag :: otherTags ->
+            li [] <|
+                text verbed
+                    :: List.intersperse (text ", ") (List.reverse otherTags)
+                    ++ [ text ", and ", lastTag, text "." ]
 
 
 viewBadMetadata : Metadata.Error -> List (Html msg)
-viewBadMetadata {message, problems} =
-  [ p []
-      [ text "The "
-      , viewCode message
-      , text " type of your program cannot be reliably serialized for history files."
-      ]
-  , p [] [ text "Functions cannot be serialized, nor can values that contain functions. This is a problem in these places:" ]
-  , ul [] (List.map viewProblemType problems)
-  , p []
-      [ text goodNews1
-      , a [ href "https://guide.elm-lang.org/types/union_types.html" ] [ text "union types" ]
-      , text ", in your messages. From there, your "
-      , viewCode "update"
-      , text goodNews2
-      ]
-  ]
+viewBadMetadata { message, problems } =
+    [ p []
+        [ text "The "
+        , viewCode message
+        , text " type of your program cannot be reliably serialized for history files."
+        ]
+    , p [] [ text "Functions cannot be serialized, nor can values that contain functions. This is a problem in these places:" ]
+    , ul [] (List.map viewProblemType problems)
+    , p []
+        [ text goodNews1
+        , a [ href "https://guide.elm-lang.org/types/union_types.html" ] [ text "union types" ]
+        , text ", in your messages. From there, your "
+        , viewCode "update"
+        , text goodNews2
+        ]
+    ]
 
 
-goodNews1 = """
+goodNews1 =
+    """
 The good news is that having values like this in your message type is not
 so great in the long run. You are better off using simpler data, like
 """
 
 
-goodNews2 = """
+goodNews2 =
+    """
 function can pattern match on that data and call whatever functions, JSON
 decoders, etc. you need. This makes the code much more explicit and easy to
 follow for other readers (or you in a few months!)
@@ -361,54 +398,54 @@ follow for other readers (or you in a few months!)
 
 viewProblemType : Metadata.ProblemType -> Html msg
 viewProblemType { name, problems } =
-  li []
-    [ viewCode name
-    , text (" can contain " ++ addCommas (List.map problemToString problems) ++ ".")
-    ]
+    li []
+        [ viewCode name
+        , text (" can contain " ++ addCommas (List.map problemToString problems) ++ ".")
+        ]
 
 
 problemToString : Metadata.Problem -> String
 problemToString problem =
-  case problem of
-    Metadata.Function ->
-      "functions"
+    case problem of
+        Metadata.Function ->
+            "functions"
 
-    Metadata.Decoder ->
-      "JSON decoders"
+        Metadata.Decoder ->
+            "JSON decoders"
 
-    Metadata.Task ->
-      "tasks"
+        Metadata.Task ->
+            "tasks"
 
-    Metadata.Process ->
-      "processes"
+        Metadata.Process ->
+            "processes"
 
-    Metadata.Socket ->
-      "web sockets"
+        Metadata.Socket ->
+            "web sockets"
 
-    Metadata.Request ->
-      "HTTP requests"
+        Metadata.Request ->
+            "HTTP requests"
 
-    Metadata.Program ->
-      "programs"
+        Metadata.Program ->
+            "programs"
 
-    Metadata.VirtualDom ->
-      "virtual DOM values"
+        Metadata.VirtualDom ->
+            "virtual DOM values"
 
 
 addCommas : List String -> String
 addCommas items =
-  case items of
-    [] ->
-      ""
+    case items of
+        [] ->
+            ""
 
-    [item] ->
-      item
+        [ item ] ->
+            item
 
-    [item1, item2] ->
-      item1 ++ " and " ++ item2
+        [ item1, item2 ] ->
+            item1 ++ " and " ++ item2
 
-    lastItem :: otherItems ->
-      String.join ", " (otherItems ++ [ " and " ++ lastItem ])
+        lastItem :: otherItems ->
+            String.join ", " (otherItems ++ [ " and " ++ lastItem ])
 
 
 
@@ -416,38 +453,38 @@ addCommas items =
 
 
 type Buttons
-  = Accept String
-  | Choose String String
+    = Accept String
+    | Choose String String
 
 
 viewButtons : Buttons -> Html Msg
 viewButtons buttons =
-  let
-    btn msg string =
-      Html.button
-        [ style "margin-right" "20px"
-        , onClick msg
+    let
+        btn msg string =
+            Html.button
+                [ style "margin-right" "20px"
+                , onClick msg
+                ]
+                [ text string ]
+
+        buttonNodes =
+            case buttons of
+                Accept proceed ->
+                    [ btn Proceed proceed
+                    ]
+
+                Choose cancel proceed ->
+                    [ btn Cancel cancel
+                    , btn Proceed proceed
+                    ]
+    in
+    div
+        [ style "height" "60px"
+        , style "line-height" "60px"
+        , style "text-align" "right"
+        , style "background-color" "rgb(50, 50, 50)"
         ]
-        [ text string ]
-
-    buttonNodes =
-      case buttons of
-        Accept proceed ->
-          [ btn Proceed proceed
-          ]
-
-        Choose cancel proceed ->
-          [ btn Cancel cancel
-          , btn Proceed proceed
-          ]
-  in
-  div
-    [ style "height" "60px"
-    , style "line-height" "60px"
-    , style "text-align" "right"
-    , style "background-color" "rgb(50, 50, 50)"
-    ]
-    buttonNodes
+        buttonNodes
 
 
 
@@ -456,47 +493,47 @@ viewButtons buttons =
 
 viewMiniControls : Config msg -> Int -> Html msg
 viewMiniControls config numMsgs =
-  div
-    [ style "position" "fixed"
-    , style "bottom" "0"
-    , style "right" "6px"
-    , style "border-radius" "4px"
-    , style "background-color" "rgb(61, 61, 61)"
-    , style "color" "white"
-    , style "font-family" "monospace"
-    , style "pointer-events" "auto"
-    , style "z-index" "2147483647"
-    ]
-    [ div
-        [ style "padding" "6px"
-        , style "cursor" "pointer"
-        , style "text-align" "center"
-        , style "min-width" "24ch"
-        , onClick config.open
+    div
+        [ style "position" "fixed"
+        , style "bottom" "0"
+        , style "right" "6px"
+        , style "border-radius" "4px"
+        , style "background-color" "rgb(61, 61, 61)"
+        , style "color" "white"
+        , style "font-family" "monospace"
+        , style "pointer-events" "auto"
+        , style "z-index" "2147483647"
         ]
-        [ text ("Explore History (" ++ String.fromInt numMsgs ++ ")")
+        [ div
+            [ style "padding" "6px"
+            , style "cursor" "pointer"
+            , style "text-align" "center"
+            , style "min-width" "24ch"
+            , onClick config.open
+            ]
+            [ text ("Explore History (" ++ String.fromInt numMsgs ++ ")")
+            ]
+        , viewImportExport
+            [ style "padding" "4px 0"
+            , style "font-size" "0.8em"
+            , style "text-align" "center"
+            , style "background-color" "rgb(50, 50, 50)"
+            ]
+            config.importHistory
+            config.exportHistory
         ]
-    , viewImportExport
-        [ style "padding" "4px 0"
-        , style "font-size" "0.8em"
-        , style "text-align" "center"
-        , style "background-color" "rgb(50, 50, 50)"
-        ]
-        config.importHistory
-        config.exportHistory
-    ]
 
 
 viewImportExport : List (Attribute msg) -> msg -> msg -> Html msg
 viewImportExport props importMsg exportMsg =
-  div
-    props
-    [ button importMsg "Import"
-    , text " / "
-    , button exportMsg "Export"
-    ]
+    div
+        props
+        [ button importMsg "Import"
+        , text " / "
+        , button exportMsg "Export"
+        ]
 
 
 button : msg -> String -> Html msg
 button msg label =
-  span [ onClick msg, style "cursor" "pointer" ] [ text label ]
+    span [ onClick msg, style "cursor" "pointer" ] [ text label ]

--- a/src/Debugger/Report.elm
+++ b/src/Debugger/Report.elm
@@ -1,99 +1,101 @@
 module Debugger.Report exposing
-  ( Report(..)
-  , Change(..)
-  , TagChanges
-  , emptyTagChanges
-  , hasTagChanges
-  , Status(..), evaluate
-  )
-
-
+    ( Change(..)
+    , Report(..)
+    , Status(..)
+    , TagChanges
+    , emptyTagChanges
+    , evaluate
+    , hasTagChanges
+    )
 
 -- REPORTS
 
 
 type Report
-  = CorruptHistory
-  | VersionChanged String String
-  | MessageChanged String String
-  | SomethingChanged (List Change)
+    = CorruptHistory
+    | VersionChanged String String
+    | MessageChanged String String
+    | SomethingChanged (List Change)
 
 
 type Change
-  = AliasChange String
-  | UnionChange String TagChanges
+    = AliasChange String
+    | UnionChange String TagChanges
 
 
 type alias TagChanges =
-  { removed : List String
-  , changed : List String
-  , added : List String
-  , argsMatch : Bool
-  }
+    { removed : List String
+    , changed : List String
+    , added : List String
+    , argsMatch : Bool
+    }
 
 
 emptyTagChanges : Bool -> TagChanges
 emptyTagChanges argsMatch =
-  TagChanges [] [] [] argsMatch
+    TagChanges [] [] [] argsMatch
 
 
 hasTagChanges : TagChanges -> Bool
 hasTagChanges tagChanges =
-  tagChanges == TagChanges [] [] [] True
+    tagChanges == TagChanges [] [] [] True
 
 
-type Status = Impossible | Risky | Fine
+type Status
+    = Impossible
+    | Risky
+    | Fine
 
 
 evaluate : Report -> Status
 evaluate report =
-  case report of
-    CorruptHistory ->
-      Impossible
+    case report of
+        CorruptHistory ->
+            Impossible
 
-    VersionChanged _ _ ->
-      Impossible
+        VersionChanged _ _ ->
+            Impossible
 
-    MessageChanged _ _ ->
-      Impossible
+        MessageChanged _ _ ->
+            Impossible
 
-    SomethingChanged changes ->
-      worstCase Fine (List.map evaluateChange changes)
+        SomethingChanged changes ->
+            worstCase Fine (List.map evaluateChange changes)
 
 
 worstCase : Status -> List Status -> Status
 worstCase status statusList =
-  case statusList of
-    [] ->
-      status
+    case statusList of
+        [] ->
+            status
 
-    Impossible :: _ ->
-      Impossible
+        Impossible :: _ ->
+            Impossible
 
-    Risky :: rest ->
-      worstCase Risky rest
+        Risky :: rest ->
+            worstCase Risky rest
 
-    Fine :: rest ->
-      worstCase status rest
+        Fine :: rest ->
+            worstCase status rest
 
 
 evaluateChange : Change -> Status
 evaluateChange change =
-  case change of
-    AliasChange _ ->
-      Impossible
+    case change of
+        AliasChange _ ->
+            Impossible
 
-    UnionChange _ { removed, changed, added, argsMatch } ->
-      if not argsMatch || some changed || some removed then
-        Impossible
+        UnionChange _ { removed, changed, added, argsMatch } ->
+            if not argsMatch || some changed || some removed then
+                Impossible
 
-      else if some added then
-        Risky
+            else if some added then
+                Risky
 
-      else
-        Fine
+            else
+                Fine
 
 
 some : List a -> Bool
 some list =
-  not (List.isEmpty list)
+    not (List.isEmpty list)

--- a/src/Elm/Kernel/Debugger.js
+++ b/src/Elm/Kernel/Debugger.js
@@ -1,7 +1,7 @@
 /*
 
 import Debugger.Expando as Expando exposing (S, Primitive, Sequence, Dictionary, Record, Constructor, ListSeq, SetSeq, ArraySeq)
-import Debugger.Main as Main exposing (getUserModel, wrapInit, wrapUpdate, wrapSubs, cornerView, popoutView, NoOp, Resize, UserMsg, Up, Down, toBlockerType)
+import Debugger.Main as Main exposing (getUserModel, wrapInit, wrapUpdate, wrapSubs, cornerView, popoutView, NoOp, Resize, UserMsg, Up, Down, Log, toBlockerType)
 import Debugger.Overlay as Overlay exposing (BlockNone, BlockMost)
 import Elm.Kernel.Browser exposing (makeAnimator)
 import Elm.Kernel.Debug exposing (crash)
@@ -200,6 +200,15 @@ function _Debugger_openWindow(popout)
 
  	popout.__sendToApp(A2(__Main_Resize, w, h));
 
+        var oldDebugLog = elm$core$Debug$log;
+	elm$core$Debug$log = F2(function(tag, value) {
+        setTimeout(function() {
+            popout.__sendToApp(A2(__Main_Log, tag, value));
+        }, 0);
+            
+            return value;
+        });
+    
 	// handle window close
 	window.addEventListener('unload', close);
 	debuggerWindow.addEventListener('unload', function() {
@@ -207,7 +216,9 @@ function _Debugger_openWindow(popout)
 		popout.__sendToApp(__Main_NoOp);
 		window.removeEventListener('unload', close);
 	});
+
 	function close() {
+		elm$core$Debug$log = oldDebugLog;
 		popout.__doc = undefined;
 		popout.__sendToApp(__Main_NoOp);
 		debuggerWindow.close();

--- a/src/Elm/Kernel/Debugger.js
+++ b/src/Elm/Kernel/Debugger.js
@@ -240,6 +240,22 @@ function _Debugger_scroll(popout)
 }
 
 
+var _Debugger_scrollTo = F2(function(id, popout)
+{
+	return __Scheduler_binding(function(callback)
+	{
+		if (popout.__doc)
+		{
+			var msg = popout.__doc.getElementById(id);
+			if (msg)
+			{
+				msg.scrollIntoView();
+			}
+		}
+		callback(__Scheduler_succeed(__Utils_Tuple0));
+	});
+});
+
 
 // UPLOAD
 

--- a/src/Elm/Kernel/Debugger.js
+++ b/src/Elm/Kernel/Debugger.js
@@ -1,7 +1,7 @@
 /*
 
 import Debugger.Expando as Expando exposing (S, Primitive, Sequence, Dictionary, Record, Constructor, ListSeq, SetSeq, ArraySeq)
-import Debugger.Main as Main exposing (getUserModel, wrapInit, wrapUpdate, wrapSubs, cornerView, popoutView, NoOp, Resize, UserMsg, Up, Down, toBlockerType)
+import Debugger.Main as Main exposing (getUserModel, wrapInit, wrapUpdate, wrapSubs, cornerView, popoutView, NoOp, Resize, UserMsg, Up, Down, toBlockerType, initialWindowWidth, initialWindowHeight)
 import Debugger.Overlay as Overlay exposing (BlockNone, BlockMost)
 import Elm.Kernel.Browser exposing (makeAnimator)
 import Elm.Kernel.Debug exposing (crash)
@@ -182,7 +182,11 @@ function _Debugger_open(popout)
 
 function _Debugger_openWindow(popout)
 {
-	var w = 900, h = 360, x = screen.width - w, y = screen.height - h;
+	var w = __Main_initialWindowWidth,
+		h = __Main_initialWindowHeight,
+	 	x = screen.width - w,
+		y = screen.height - h;
+
 	var debuggerWindow = window.open('', '', 'width=' + w + ',height=' + h + ',left=' + x + ',top=' + y);
 	var doc = debuggerWindow.document;
 	doc.title = 'Elm Debugger';

--- a/src/Elm/Kernel/Debugger.js
+++ b/src/Elm/Kernel/Debugger.js
@@ -73,12 +73,13 @@ var _Debugger_element = F4(function(impl, flagDecoder, debugMetadata, args)
 
 				// view corner
 
+				var cornerNext = __Main_cornerView(model);
+				var cornerPatches = __VirtualDom_diff(cornerCurr, cornerNext);
+				cornerNode = __VirtualDom_applyPatches(cornerNode, cornerCurr, cornerPatches, sendToApp);
+				cornerCurr = cornerNext;
+
 				if (!model.__$popout.__doc)
 				{
-					var cornerNext = __Main_cornerView(model);
-					var cornerPatches = __VirtualDom_diff(cornerCurr, cornerNext);
-					cornerNode = __VirtualDom_applyPatches(cornerNode, cornerCurr, cornerPatches, sendToApp);
-					cornerCurr = cornerNext;
 					currPopout = undefined;
 					return;
 				}

--- a/src/Elm/Kernel/Debugger.js
+++ b/src/Elm/Kernel/Debugger.js
@@ -230,9 +230,9 @@ function _Debugger_scroll(popout)
 		if (popout.__doc)
 		{
 			var msgs = popout.__doc.getElementById('elm-debugger-sidebar');
-			if (msgs)
+			if (msgs && msgs.scrollTop !== 0)
 			{
-				msgs.scrollTop = msgs.scrollHeight;
+				msgs.scrollTop = 0;
 			}
 		}
 		callback(__Scheduler_succeed(__Utils_Tuple0));

--- a/src/Elm/Kernel/Debugger.js
+++ b/src/Elm/Kernel/Debugger.js
@@ -249,7 +249,7 @@ var _Debugger_scrollTo = F2(function(id, popout)
 			var msg = popout.__doc.getElementById(id);
 			if (msg)
 			{
-				msg.scrollIntoView();
+				msg.scrollIntoView(false);
 			}
 		}
 		callback(__Scheduler_succeed(__Utils_Tuple0));

--- a/src/Elm/Kernel/Debugger.js
+++ b/src/Elm/Kernel/Debugger.js
@@ -1,7 +1,7 @@
 /*
 
 import Debugger.Expando as Expando exposing (S, Primitive, Sequence, Dictionary, Record, Constructor, ListSeq, SetSeq, ArraySeq)
-import Debugger.Main as Main exposing (getUserModel, wrapInit, wrapUpdate, wrapSubs, cornerView, popoutView, NoOp, UserMsg, Up, Down, toBlockerType)
+import Debugger.Main as Main exposing (getUserModel, wrapInit, wrapUpdate, wrapSubs, cornerView, popoutView, NoOp, Resize, UserMsg, Up, Down, toBlockerType)
 import Debugger.Overlay as Overlay exposing (BlockNone, BlockMost)
 import Elm.Kernel.Browser exposing (makeAnimator)
 import Elm.Kernel.Debug exposing (crash)
@@ -193,6 +193,12 @@ function _Debugger_openWindow(popout)
 		event.which === 38 && (popout.__sendToApp(__Main_Up), event.preventDefault());
 		event.which === 40 && (popout.__sendToApp(__Main_Down), event.preventDefault());
 	});
+
+ 	debuggerWindow.addEventListener('resize', function(event) {
+ 		popout.__sendToApp(A2(__Main_Resize, debuggerWindow.innerWidth, debuggerWindow.innerHeight));
+ 	});
+
+ 	popout.__sendToApp(A2(__Main_Resize, w, h));
 
 	// handle window close
 	window.addEventListener('unload', close);

--- a/src/Elm/Kernel/Debugger.js
+++ b/src/Elm/Kernel/Debugger.js
@@ -236,11 +236,12 @@ function _Debugger_scroll(popout)
 // UPLOAD
 
 
-function _Debugger_upload()
+function _Debugger_upload(popout)
 {
 	return __Scheduler_binding(function(callback)
 	{
-		var element = document.createElement('input');
+		var doc = popout.__doc || document;
+		var element = doc.createElement('input');
 		element.setAttribute('type', 'file');
 		element.setAttribute('accept', 'text/json');
 		element.style.display = 'none';
@@ -252,9 +253,9 @@ function _Debugger_upload()
 				callback(__Scheduler_succeed(e.target.result));
 			};
 			fileReader.readAsText(event.target.files[0]);
-			document.body.removeChild(element);
+			doc.body.removeChild(element);
 		});
-		document.body.appendChild(element);
+		doc.body.appendChild(element);
 		element.click();
 	});
 }

--- a/src/Elm/Kernel/Debugger.js
+++ b/src/Elm/Kernel/Debugger.js
@@ -1,7 +1,7 @@
 /*
 
 import Debugger.Expando as Expando exposing (S, Primitive, Sequence, Dictionary, Record, Constructor, ListSeq, SetSeq, ArraySeq)
-import Debugger.Main as Main exposing (getUserModel, wrapInit, wrapUpdate, wrapSubs, cornerView, popoutView, NoOp, Resize, UserMsg, Up, Down, Log, toBlockerType)
+import Debugger.Main as Main exposing (getUserModel, wrapInit, wrapUpdate, wrapSubs, cornerView, popoutView, NoOp, Resize, UserMsg, Up, Down, toBlockerType)
 import Debugger.Overlay as Overlay exposing (BlockNone, BlockMost)
 import Elm.Kernel.Browser exposing (makeAnimator)
 import Elm.Kernel.Debug exposing (crash)
@@ -200,15 +200,6 @@ function _Debugger_openWindow(popout)
 
  	popout.__sendToApp(A2(__Main_Resize, w, h));
 
-        var oldDebugLog = elm$core$Debug$log;
-	elm$core$Debug$log = F2(function(tag, value) {
-        setTimeout(function() {
-            popout.__sendToApp(A2(__Main_Log, tag, value));
-        }, 0);
-            
-            return value;
-        });
-    
 	// handle window close
 	window.addEventListener('unload', close);
 	debuggerWindow.addEventListener('unload', function() {
@@ -218,7 +209,6 @@ function _Debugger_openWindow(popout)
 	});
 
 	function close() {
-		elm$core$Debug$log = oldDebugLog;
 		popout.__doc = undefined;
 		popout.__sendToApp(__Main_NoOp);
 		debuggerWindow.close();
@@ -559,4 +549,3 @@ var _Debugger_mostEvents = [
 ];
 
 var _Debugger_allEvents = _Debugger_mostEvents.concat('wheel', 'scroll');
-


### PR DESCRIPTION
This PR includes:

* bugfixes from #69 
* Add slider to easily move backwards and forwards in history
* Fixes performance degression with many messages (should make debugger more usable in games)
* When paused, messages caused by animationRequests don't enter the view (typical issue in games).
* Adds a new layout when width < height
* Message panel is now resizable
* Messages can now be explored in exploration panel
* Order of messages is reversed. This gives us a minor performance improvement, and allows the scrollbar to fade away on Mac OS.