### PR TITLE
Add class to elm debugger

### DIFF
--- a/src/Debugger/Overlay.elm
+++ b/src/Debugger/Overlay.elm
@@ -135,7 +135,8 @@ view config isPaused isOpen numMsgs state =
       else
         if isPaused then
           div
-            [ style "width" "100%"
+            [ class "__elm__internal__debugger__"
+            , style "width" "100%"
             , style "height" "100%"
             , style "cursor" "pointer"
             , style "text-align" "center"


### PR DESCRIPTION
This PR adds the class `__elm__internal__debugger__` to the widget that lives to the bottom-right of the screen and is used to open the debugger.

This is useful for possible overrides that users may want to do (move the debugger to the right, lift if up a little, etc).

I'm open to discussion, but this would be very useful for us, since we've a toast notification system that doesn't work well in development since the huge `z-index` of the said widget doesn't allow for any exact override. A class would be a huge helper, and hopefully has a minimal impact
