### PR TITLE
Add and expose screen touch events

### DIFF
--- a/src/Browser/Events.elm
+++ b/src/Browser/Events.elm
@@ -2,6 +2,7 @@ effect module Browser.Events where { subscription = MySub } exposing
   ( onAnimationFrame, onAnimationFrameDelta
   , onKeyPress, onKeyDown, onKeyUp
   , onClick, onMouseMove, onMouseDown, onMouseUp
+  , onTouchStart, onTouchEnd, onTouchCancel, onTouchMove
   , onResize, onVisibilityChange, Visibility(..)
   )
 
@@ -29,6 +30,10 @@ If there is something else you need, use [ports] to do it in JavaScript!
 
 @docs onClick, onMouseMove, onMouseDown, onMouseUp
 
+
+# Touchscreen
+
+@docs onTouchStart, onTouchEnd, onTouchCancel, onTouchMove
 
 # Window
 
@@ -175,6 +180,33 @@ to be sure keys do not appear to down and never come back up.
 onMouseUp : Decode.Decoder msg -> Sub msg
 onMouseUp =
   on Document "mouseup"
+
+-- TOUCHSCREEN
+
+{-| Subscribe to touch start events anywhere on screen.
+-}
+onTouchStart : Decode.Decoder msg -> Sub msg
+onTouchStart =
+  on Document "touchstart"
+
+
+{-| Subscribe to touch end events anywhere on screen.
+-}
+onTouchEnd : Decode.Decoder msg -> Sub msg
+onTouchEnd =
+  on Document "touchend"
+
+{-| Subscribe to touch cancel events anywhere on screen.
+-}
+onTouchCancel : Decode.Decoder msg -> Sub msg
+onTouchCancel =
+  on Document "touchcancel"
+
+{-| Subscribe to touch movement events anywhere on screen.
+-}
+onTouchMove : Decode.Decoder msg -> Sub msg
+onTouchMove =
+  on Document "touchmove"
 
 
 


### PR DESCRIPTION
Whereas there is a fantastic Elm library enabling the subscription to touch events https://github.com/mpizenberg/elm-pointer-events/blob/4.0.2/src/Html/Events/Extra/Touch.elm

For example, I've a fork of `elm-playground` which leverages it to allow the implementation of games with touch inputs: https://github.com/pfcoperez/elm-playground/blob/743f0a51213bba6685352a5d9376fe978c378f60/src/Playground.elm#L1523-L1537

```elm
    [ Touch.onStart onTouchEvent
    , Touch.onMove onTouchEvent
    , Touch.onEnd onTouchEvent
    , Touch.onCancel onTouchEvent
    , viewBox (x ++ " " ++ y ++ " " ++ w ++ " " ++ h)
    , H.style "position" "fixed"
    , H.style "top" "0"
    , H.style "left" "0"
    , width "100%"
    , height "100%"
    ]
    (List.map renderShape shapes)


onTouchEvent : Touch.Event -> Msg
onTouchEvent t = TouchMove (Maybe.map (\touch -> touch.clientPos) (List.head t.touches))
```

```elm
    TouchMove maybeTouch ->
      let
        touchPosToPos (pageX, pageY) =
          { x = computer.screen.left + pageX
          , y = computer.screen.top - pageY
          }
        maybePos = Maybe.map touchPosToPos maybeTouch
      in Game vis memory { computer | touch = TouchState maybePos }
```

It'd be nice to be able to listen to these ones using the core browser library. This would lead to more consistent usage of these events in `elm-playground`  and other libraries and applications.

This PR adds the helper functions to subscribe to touch events.