### PR TITLE
Fix typo in Browser.Dom.getViewportOf documentation

### DIFF
--- a/src/Browser/Dom.elm
+++ b/src/Browser/Dom.elm
@@ -173,7 +173,7 @@ type alias Viewport =
 
 
 {-| Just like `getViewport`, but for any scrollable DOM node. Say we have an
-application with a chat box in the bottow right corner like this:
+application with a chat box in the bottom right corner like this:
 
 ![chat](https://elm.github.io/browser/v1/chat.svg)
 


### PR DESCRIPTION
Just fix typo.