### PR TITLE
Fix debugger background color

### DIFF
--- a/src/Debugger/Main.elm
+++ b/src/Debugger/Main.elm
@@ -506,6 +506,7 @@ popoutView model =
       , style "height" "100%"
       , style "font-family" "monospace"
       , style "display" "flex"
+      , style "background-color" "white"
       , style "flex-direction" (toFlexDirection model.layout)
       ]
     )


### PR DESCRIPTION
When using Firefox in dark mode, `about:blank` has a dark background instead of white. The debugger popup window uses `about:blank`, and as such we get the dark background in the debugger. The text is hard to read then.

When a web page does not set the page background color, it is up to the user agent to decide the background color. Firefox lets you configure this background color. So it is a good idea to set the page background color anyway.

Ideally, we’d have a dark mode for the debugger too, but that is out of scope for this PR.

| Before | After |
| - | - |
| <img width="946" alt="Screenshot 2025-06-01 at 22 24 25" src="https://github.com/user-attachments/assets/e40630a5-0aa6-4389-b8f9-afd119a25f9b" /> |  <img width="946" alt="Screenshot 2025-06-01 at 22 26 45" src="https://github.com/user-attachments/assets/85f8774d-1107-47d1-b423-1551d5585680" /> |

_Note to those following along: This PR is included in https://github.com/lydell/browser/tree/safe, which is part of https://github.com/lydell/elm-safe-virtual-dom, but it has nothing to do with “safe virtual DOM” really, it’s just in there because it’s convenient._