### PR TITLE
Allow virtualization to set up link click listeners

### DIFF
--- a/src/Elm/Kernel/Browser.js
+++ b/src/Elm/Kernel/Browser.js
@@ -75,7 +75,9 @@ var _Browser_document = __Debugger_document || F4(function(impl, flagDecoder, de
 			var view = impl.__$view;
 			var title = __VirtualDom_doc.title;
 			var bodyNode = __VirtualDom_doc.body;
+			__VirtualDom_divertHrefToApp = divertHrefToApp;
 			var currNode = _VirtualDom_virtualize(bodyNode);
+			__VirtualDom_divertHrefToApp = 0;
 			return _Browser_makeAnimator(initialModel, function(model)
 			{
 				__VirtualDom_divertHrefToApp = divertHrefToApp;

--- a/src/Elm/Kernel/Debugger.js
+++ b/src/Elm/Kernel/Debugger.js
@@ -113,7 +113,9 @@ var _Debugger_document = F4(function(impl, flagDecoder, debugMetadata, args)
 			var view = impl.__$view;
 			var title = __VirtualDom_doc.title;
 			var bodyNode = __VirtualDom_doc.body;
+			__VirtualDom_divertHrefToApp = divertHrefToApp;
 			var currNode = __VirtualDom_virtualize(bodyNode);
+			__VirtualDom_divertHrefToApp = 0;
 			var currBlocker = __Main_toBlockerType(initialModel);
 			var currPopout;
 


### PR DESCRIPTION
Closes https://github.com/elm/browser/issues/105 together with https://github.com/elm/virtual-dom/pull/187

The code already sets `__VirtualDom_divertHrefToApp` before each render, so that `<a>` elements created during the render can get a click listener that directs the link click to the `update` function, letting it decided what should happen. https://github.com/elm/browser/blob/1.0.2/src/Elm/Kernel/Browser.js#L81-L87

This PR also sets `__VirtualDom_divertHrefToApp` before _virtualization,_ so that `<a>` HTML elements that are picked up by Elm during initialization also can get their click listener – which is implemented in https://github.com/elm/virtual-dom/pull/187.

_Note to those following along: This PR is included in https://github.com/lydell/browser/tree/safe, which is part of https://github.com/lydell/elm-safe-virtual-dom._