### PR TITLE
Fix animation frames

### DIFF
--- a/src/Elm/Kernel/Browser.js
+++ b/src/Elm/Kernel/Browser.js
@@ -144,7 +144,7 @@ var _Browser_requestAnimationFrame_raw =
 // its `connectedCallback`, which happens synchronously. That causes
 // `update` to run while we’re in the middle of drawing, which then
 // causes another call to the returned function below. We can’t start
-// another draw while before the first one is finished.
+// another draw before the first one is finished.
 // Another thing you can do in `connectedCallback`, is to initialize
 // another Elm app. Even different app instances can conflict with each other,
 // since they all use the same `_VirtualDom_renderCount` variable.

--- a/src/Elm/Kernel/Browser.js
+++ b/src/Elm/Kernel/Browser.js
@@ -139,20 +139,16 @@ var _Browser_requestAnimationFrame_raw =
 		? requestAnimationFrame
 		: function(callback) { return setTimeout(callback, 1000 / 60); };
 
-// Whether `draw` is currently running. `draw` can cause side effects:
-// If the user renders a custom element, they can dispatch an event in
-// its `connectedCallback`, which happens synchronously. That causes
-// `update` to run while we’re in the middle of drawing, which then
-// causes another call to the returned function below. We can’t start
-// another draw before the first one is finished.
-// Another thing you can do in `connectedCallback`, is to initialize
-// another Elm app. Even different app instances can conflict with each other,
-// since they all use the same `_VirtualDom_renderCount` variable.
-var _Browser_drawing = false;
-var _Browser_drawSync_queue = [];
-
 function _Browser_makeAnimator(model, draw)
 {
+	// Whether `draw` is currently running. `draw` can cause side effects:
+	// If the user renders a custom element, they can dispatch an event in
+	// its `connectedCallback`, which happens synchronously. That causes
+	// `update` to run while we’re in the middle of drawing, which then
+	// causes another call to the returned function below. We can’t start
+	// another draw while before the first one is finished.
+	var drawing = false;
+
 	// Whether we have already requested an animation frame for drawing.
 	var pendingFrame = false;
 
@@ -162,26 +158,21 @@ function _Browser_makeAnimator(model, draw)
 	function drawHelp()
 	{
 		// If we’re already drawing, wait until that draw is done.
-		if (_Browser_drawing)
+		if (drawing)
 		{
-			if (!pendingSync)
-			{
-				pendingSync = true;
-				_Browser_drawSync_queue.push(drawHelp);
-			}
+			pendingSync = true;
 			return;
 		}
 
 		pendingFrame = false;
 		pendingSync = false;
-		_Browser_drawing = true;
+		drawing = true;
 		draw(model);
-		_Browser_drawing = false;
+		drawing = false;
 
-		while (_Browser_drawSync_queue.length > 0)
+		if (pendingSync)
 		{
-			var callback = _Browser_drawSync_queue.shift();
-			callback();
+			drawHelp();
 		}
 	}
 

--- a/src/Elm/Kernel/Browser.js
+++ b/src/Elm/Kernel/Browser.js
@@ -96,41 +96,121 @@ var _Browser_document = __Debugger_document || F4(function(impl, flagDecoder, de
 // ANIMATION
 
 
-var _Browser_cancelAnimationFrame =
-	typeof cancelAnimationFrame !== 'undefined'
-		? cancelAnimationFrame
-		: function(id) { clearTimeout(id); };
+var _Browser_requestAnimationFrame_queue = {};
+var _Browser_inAnimationFrame = false;
+var _Browser_pendingAnimationFrame = false;
+var _Browser_requestAnimationFrame_id = 0;
 
-var _Browser_requestAnimationFrame =
+function _Browser_cancelAnimationFrame(id)
+{
+	delete _Browser_requestAnimationFrame_queue[id];
+}
+
+function _Browser_requestAnimationFrame(callback)
+{
+	var id = _Browser_requestAnimationFrame_id;
+	_Browser_requestAnimationFrame_id++;
+	_Browser_requestAnimationFrame_queue[id] = callback;
+	if (!_Browser_pendingAnimationFrame)
+	{
+		_Browser_pendingAnimationFrame = true;
+		_Browser_requestAnimationFrame_raw(function() {
+			_Browser_pendingAnimationFrame = false;
+			_Browser_inAnimationFrame = true;
+			var maxId = _Browser_requestAnimationFrame_id;
+			for (var id2 in _Browser_requestAnimationFrame_queue)
+			{
+				if (id2 >= maxId)
+				{
+					break;
+				}
+				var callback = _Browser_requestAnimationFrame_queue[id2];
+				delete _Browser_requestAnimationFrame_queue[id2];
+				callback();
+			}
+			_Browser_inAnimationFrame = false;
+		});
+	}
+	return id;
+}
+
+var _Browser_requestAnimationFrame_raw =
 	typeof requestAnimationFrame !== 'undefined'
 		? requestAnimationFrame
 		: function(callback) { return setTimeout(callback, 1000 / 60); };
 
+// Whether `draw` is currently running. `draw` can cause side effects:
+// If the user renders a custom element, they can dispatch an event in
+// its `connectedCallback`, which happens synchronously. That causes
+// `update` to run while we’re in the middle of drawing, which then
+// causes another call to the returned function below. We can’t start
+// another draw while before the first one is finished.
+// Another thing you can do in `connectedCallback`, is to initialize
+// another Elm app. Even different app instances can conflict with each other,
+// since they all use the same `_VirtualDom_renderCount` variable.
+var _Browser_drawing = false;
+var _Browser_drawSync_queue = [];
 
 function _Browser_makeAnimator(model, draw)
 {
-	draw(model);
+	// Whether we have already requested an animation frame for drawing.
+	var pendingFrame = false;
 
-	var state = __4_NO_REQUEST;
+	// Whether we have already requested to draw right after the current draw has finished.
+	var pendingSync = false;
+
+	function drawHelp()
+	{
+		// If we’re already drawing, wait until that draw is done.
+		if (_Browser_drawing)
+		{
+			if (!pendingSync)
+			{
+				pendingSync = true;
+				_Browser_drawSync_queue.push(drawHelp);
+			}
+			return;
+		}
+
+		pendingFrame = false;
+		pendingSync = false;
+		_Browser_drawing = true;
+		draw(model);
+		_Browser_drawing = false;
+
+		while (_Browser_drawSync_queue.length > 0)
+		{
+			var callback = _Browser_drawSync_queue.shift();
+			callback();
+		}
+	}
 
 	function updateIfNeeded()
 	{
-		state = state === __4_EXTRA_REQUEST
-			? __4_NO_REQUEST
-			: ( _Browser_requestAnimationFrame(updateIfNeeded), draw(model), __4_EXTRA_REQUEST );
+		if (pendingFrame)
+		{
+			drawHelp();
+		}
 	}
+
+	drawHelp();
 
 	return function(nextModel, isSync)
 	{
 		model = nextModel;
 
-		isSync
-			? ( draw(model),
-				state === __4_PENDING_REQUEST && (state = __4_EXTRA_REQUEST)
-				)
-			: ( state === __4_NO_REQUEST && _Browser_requestAnimationFrame(updateIfNeeded),
-				state = __4_PENDING_REQUEST
-				);
+		// When using `Browser.Events.onAnimationFrame` we already are
+		// in an animation frame, so draw straight away. Otherwise we’ll
+		// be drawing one frame late all the time.
+		if (isSync || _Browser_inAnimationFrame)
+		{
+			drawHelp();
+		}
+		else if (!pendingFrame)
+		{
+			pendingFrame = true;
+			_Browser_requestAnimationFrame(updateIfNeeded);
+		}
 	};
 }
 


### PR DESCRIPTION
When Elm’s virtual DOM crashes, you get an error in the browser console many times per second. This is because Elm generally draws on the next animation frame using `requestAnimationFrame`, and if it crashes during rendering it gets stuck in an infinite `requestAnimationFrame` loop. That’s really annoying. This PR makes sure it doesn’t get stuck in a loop on error.

When changing the code to not get caught in a loop if there is an exception, I also noticed that the whole `requestAnimationFrame` was a bit off. Basically, if you also subscribe to `Browser.Events.onAnimationFrame`, you could end up with `update` and `view` being 1 frame out of sync, and some frames could be skipped. I made a [demo showing these animation frame oddities](https://lydell.github.io/elm-animation-frame-oddities/). This PR fixes that, too, except the demo cases where the animation frames come via a port – I don’t think that is solvable.

The old implementation was really clever: When rendering, it basically always ran `requestAnimationFrame` one time extra, just in case there is a `Browser.Events.onAnimationFrame`, so that there’s always a render queued up for the next animation frame ready to go, without having to wait until the _next_ frame. But if there is no `Browser.Events.onAnimationFrame` subscription, the system only resulted in _one_ extra `requestAnimationFrame` call (it’s not like Elm is constantly doing things on every single animation frame, many times per second). While I appreciate the cleverness of the old implementation, it unfortunately resulted in `update` and `view` being 1 frame out of sync, and some frames could be skipped, as mentioned above. The new implementation instead wraps `requestAnimationFrame` to keep track of whether we are currently in an animation frame or not.

_Note to those following along: This PR is included in https://github.com/lydell/browser/tree/safe, which is part of https://github.com/lydell/elm-safe-virtual-dom. This is only related to “safe virtual DOM” in the form that if the rendering crashes, it won’t loop in a tight `requestAnimationFrame` loop._