### PR TITLE
Fix links without href

### DIFF
--- a/src/Elm/Kernel/Browser.js
+++ b/src/Elm/Kernel/Browser.js
@@ -154,7 +154,7 @@ function _Browser_application(impl)
 
 			return F2(function(domNode, event)
 			{
-				if (!event.ctrlKey && !event.metaKey && !event.shiftKey && event.button < 1 && !domNode.target && !domNode.hasAttribute('download'))
+				if (!event.ctrlKey && !event.metaKey && !event.shiftKey && event.button < 1 && !domNode.target && !domNode.hasAttribute('download') && domNode.hasAttribute('href'))
 				{
 					event.preventDefault();
 					var href = domNode.href;


### PR DESCRIPTION
Closes [elm/browser#34](https://github.com/elm/browser/issues/34), closes [elm/browser#55](https://github.com/elm/browser/issues/55), closes [elm/browser#64](https://github.com/elm/browser/issues/64), closes https://github.com/elm/virtual-dom/pull/142.

`<a>` elements without `href` aren’t clickable in plain HTML. However, in `Browser.application` programs, clicking them still produces a message.

> The [href](https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-href) attribute on [a](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element) and [area](https://html.spec.whatwg.org/multipage/image-maps.html#the-area-element) elements is not required; when those elements do not have [href](https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-href) attributes they do not create hyperlinks.
>
> — https://html.spec.whatwg.org/multipage/links.html#links-created-by-a-and-area-elements

> If the [a](https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element) element has no [href](https://html.spec.whatwg.org/multipage/links.html#attr-hyperlink-href) attribute, then the element [represents](https://html.spec.whatwg.org/multipage/dom.html#represents) a placeholder for where a link might otherwise have been placed, if it had been relevant, consisting of just the element's contents.
>
> — https://html.spec.whatwg.org/multipage/text-level-semantics.html#the-a-element

_Note to those following along: This PR is included in https://github.com/lydell/browser/tree/safe, which is part of https://github.com/lydell/elm-safe-virtual-dom, but it has nothing to do with “safe virtual DOM” really, it’s just in there because it’s convenient._