### PR TITLE
Fix debugger virtualization

### DIFF
--- a/src/Elm/Kernel/Debugger.js
+++ b/src/Elm/Kernel/Debugger.js
@@ -46,7 +46,6 @@ var _Debugger_element = F4(function(impl, flagDecoder, debugMetadata, args)
 		function(sendToApp, initialModel)
 		{
 			var view = impl.__$view;
-			var title = __VirtualDom_doc.title;
 			var domNode = args && args['node'] ? args['node'] : __Debug_crash(0);
 			var currNode = __VirtualDom_virtualize(domNode);
 			var currBlocker = __Main_toBlockerType(initialModel);
@@ -87,7 +86,7 @@ var _Debugger_element = F4(function(impl, flagDecoder, debugMetadata, args)
 				// view popout
 
 				__VirtualDom_doc = model.__$popout.__doc; // SWITCH TO POPOUT DOC
-				currPopout || (currPopout = __VirtualDom_virtualize(model.__$popout.__doc));
+				currPopout || (currPopout = __VirtualDom_virtualize(model.__$popout.__doc.body));
 				var nextPopout = __Main_popoutView(model);
 				var popoutPatches = __VirtualDom_diff(currPopout, nextPopout);
 				__VirtualDom_applyPatches(model.__$popout.__doc.body, currPopout, popoutPatches, sendToApp);
@@ -146,7 +145,7 @@ var _Debugger_document = F4(function(impl, flagDecoder, debugMetadata, args)
 				if (!model.__$popout.__doc) { currPopout = undefined; return; }
 
 				__VirtualDom_doc = model.__$popout.__doc; // SWITCH TO POPOUT DOC
-				currPopout || (currPopout = __VirtualDom_virtualize(model.__$popout.__doc));
+				currPopout || (currPopout = __VirtualDom_virtualize(model.__$popout.__doc.body));
 				var nextPopout = __Main_popoutView(model);
 				var popoutPatches = __VirtualDom_diff(currPopout, nextPopout);
 				__VirtualDom_applyPatches(model.__$popout.__doc.body, currPopout, popoutPatches, sendToApp);


### PR DESCRIPTION
In the debugger popup, the whole `document` is accidentally passed to `__VirtualDom_virtualize`, instead of `document.body`. The code happens to work anyway. However, in https://github.com/elm/virtual-dom/pull/187 that results in the debugger popup being a blank page, due to the virtualization fixes in that PR.

This PR fixes this oversight, passing `.body` to the virtualization as intended.

https://github.com/elm/virtual-dom/pull/187 still works without this PR, because I added a special case there. Basically, `if (node === document) { node = document.body; }`. This is so that https://github.com/elm/virtual-dom/pull/187 isn’t a breaking change (installing that but not this fix in elm/browser would lead to a broken debugger). I still felt like it was worth fixing this problem in the “right” place, too.

_Note to those following along: This PR is included in https://github.com/lydell/browser/tree/safe, which is part of https://github.com/lydell/elm-safe-virtual-dom._