### PR TITLE
Display custom type variants starting with non-ASCII in debugger

### DIFF
--- a/src/Elm/Kernel/Debugger.js
+++ b/src/Elm/Kernel/Debugger.js
@@ -437,18 +437,18 @@ function _Debugger_init(value)
 		}
 
 		var char = tag.charCodeAt(0);
-		if (char === 35 || 65 <= char && char <= 90)
+		if (/* a */ 0x61 <= char && char <= 0x7A /* z */)
 		{
-			var list = __List_Nil;
-			for (var i in value)
-			{
-				if (i === '$') continue;
-				list = __List_Cons(_Debugger_init(value[i]), list);
-			}
-			return A3(__Expando_Constructor, char === 35 ? __Maybe_Nothing : __Maybe_Just(tag), true, __List_reverse(list));
+			return __Expando_Primitive('<internals>');
 		}
 
-		return __Expando_Primitive('<internals>');
+		var list = __List_Nil;
+		for (var i in value)
+		{
+			if (i === '$') continue;
+			list = __List_Cons(_Debugger_init(value[i]), list);
+		}
+		return A3(__Expando_Constructor, char === 35 ? __Maybe_Nothing : __Maybe_Just(tag), true, __List_reverse(list));
 	}
 
 	if (typeof value === 'object')


### PR DESCRIPTION
Fixes https://github.com/elm/browser/issues/141

The solution is to use the `_Debugger_messageToString` approach in `_Debugger_init` too: Hide ASCII lowercase, and display others.

The diff is best displayed [without whitespace changes](https://github.com/elm/browser/pull/142/files?w=1).

| Before | After |
| - | - |
| <img width="1012" alt="before" src="https://github.com/user-attachments/assets/4302e8cc-31da-4f52-87e8-f85b395748c5" /> | <img width="1012" alt="after" src="https://github.com/user-attachments/assets/8e4c9d66-eb09-4a45-b9af-bfb44f5ec511" /> |

_Note to those following along: This PR is included in https://github.com/lydell/browser/tree/safe, which is part of https://github.com/lydell/elm-safe-virtual-dom, but it has nothing to do with “safe virtual DOM” really, it’s just in there because it’s convenient._